### PR TITLE
styles: update font to noto

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,8 +8,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-noto-sans);
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
### TL;DR

Replaced Geist fonts with Noto Sans as the default sans-serif font and removed the mono font variable.

### What changed?

- Removed `--font-geist-sans` and replaced it with `--font-noto-sans` as the value for `--font-sans` CSS variable
- Removed the `--font-mono: var(--font-geist-mono)` CSS variable entirely

### How to test?

1. Run the application and verify that text renders properly with Noto Sans
2. Check that the UI appearance is consistent across different components
3. Verify that any monospace text still renders appropriately despite the removal of the dedicated mono font variable

### Why make this change?

Noto Sans provides better multilingual support and consistent rendering across different platforms compared to Geist. The mono font variable was likely removed to simplify the font system or because monospace text is being handled differently elsewhere in the application.