### PR TITLE
feat: import noto font

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,9 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Noto_Sans } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const notoSans = Noto_Sans({
+  variable: "--font-noto-sans",
   subsets: ["latin"],
 });
 
@@ -24,11 +19,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
+      <body className={`${notoSans.variable} antialiased`}>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
### TL;DR

Replace Geist fonts with Noto Sans in the application layout.

### What changed?

- Removed `Geist` and `Geist_Mono` font imports
- Added `Noto_Sans` font import
- Updated the font variable from `--font-geist-sans` and `--font-geist-mono` to `--font-noto-sans`
- Simplified the body class by removing the Geist Mono variable

### How to test?

1. Run the application locally
2. Verify that the font has changed to Noto Sans throughout the application
3. Check that text renders properly in different browser environments

### Why make this change?

Noto Sans provides better multilingual support and consistent rendering across different platforms. This change simplifies our font management by using a single font family instead of maintaining separate sans and mono variants.