### PR TITLE
feat: setup editor and extensions

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { EditorContent, EditorRoot, JSONContent } from "novel";
+import { useState } from "react";
+import { defaultExtensions } from "@/lib/extensions";
+
+const extensions = [...defaultExtensions];
+
+const defaultContent = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "What's on your mind?" }],
+    },
+  ],
+};
+
+const Editor = () => {
+  const [content, setContent] = useState<JSONContent | null>(defaultContent);
+
+  return (
+    <div className="h-full">
+      <EditorRoot>
+        <EditorContent
+          className="h-full"
+          extensions={extensions}
+          initialContent={content || undefined}
+          onUpdate={({ editor }) => {
+            const json = editor.getJSON();
+            console.log("Editor", json);
+            setContent(json);
+          }}
+        />
+      </EditorRoot>
+    </div>
+  );
+};
+
+export default Editor;

--- a/src/lib/extensions.ts
+++ b/src/lib/extensions.ts
@@ -1,0 +1,93 @@
+import {
+  TiptapImage,
+  TiptapLink,
+  UpdatedImage,
+  TaskList,
+  TaskItem,
+  HorizontalRule,
+  StarterKit,
+  Placeholder,
+} from "novel";
+
+import { cx } from "class-variance-authority";
+
+// TODO I am using cx here to get tailwind autocomplete working, idk if someone else can write a regex to just capture the class key in objects
+
+// You can overwrite the placeholder with your own configuration
+const placeholder = Placeholder;
+const tiptapLink = TiptapLink.configure({
+  HTMLAttributes: {
+    class: cx(
+      "text-muted-foreground underline underline-offset-[3px] hover:text-primary transition-colors cursor-pointer"
+    ),
+  },
+});
+
+const taskList = TaskList.configure({
+  HTMLAttributes: {
+    class: cx("not-prose pl-2"),
+  },
+});
+const taskItem = TaskItem.configure({
+  HTMLAttributes: {
+    class: cx("flex items-start my-4"),
+  },
+  nested: true,
+});
+
+const horizontalRule = HorizontalRule.configure({
+  HTMLAttributes: {
+    class: cx("mt-4 mb-6 border-t border-muted-foreground"),
+  },
+});
+
+const starterKit = StarterKit.configure({
+  bulletList: {
+    HTMLAttributes: {
+      class: cx("list-disc list-outside leading-3 -mt-2"),
+    },
+  },
+  orderedList: {
+    HTMLAttributes: {
+      class: cx("list-decimal list-outside leading-3 -mt-2"),
+    },
+  },
+  listItem: {
+    HTMLAttributes: {
+      class: cx("leading-normal -mb-2"),
+    },
+  },
+  blockquote: {
+    HTMLAttributes: {
+      class: cx("border-l-4 border-primary"),
+    },
+  },
+  codeBlock: {
+    HTMLAttributes: {
+      class: cx("rounded-sm bg-muted border p-5 font-mono font-medium"),
+    },
+  },
+  code: {
+    HTMLAttributes: {
+      class: cx("rounded-md bg-muted  px-1.5 py-1 font-mono font-medium"),
+      spellcheck: "false",
+    },
+  },
+  horizontalRule: false,
+  dropcursor: {
+    color: "#DBEAFE",
+    width: 4,
+  },
+  gapcursor: false,
+});
+
+export const defaultExtensions = [
+  starterKit,
+  placeholder,
+  TiptapLink,
+  TiptapImage,
+  UpdatedImage,
+  taskList,
+  taskItem,
+  horizontalRule,
+];


### PR DESCRIPTION
### TL;DR

Added a rich text editor component using Novel.js with customized extensions.

### What changed?

- Created a new `Editor.tsx` component that implements a rich text editor with Novel.js
- Added a default placeholder text "What's on your mind?"
- Implemented state management for editor content using React useState
- Created a new `extensions.ts` library file with customized text formatting options
- Configured various text elements (links, task lists, blockquotes, code blocks) with tailwind styling

### How to test?

1. Import and render the `Editor` component in a page
2. Type in the editor to replace the placeholder text
3. Check the console logs to see the JSON representation of the content
4. Test various text formatting options provided by the extensions

### Why make this change?

To provide a rich text editing experience with a clean, customizable interface. The Novel.js integration allows for advanced text editing capabilities while maintaining control over the styling and behavior through the custom extensions.