### PR TITLE
feat: add editor to main page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,11 @@
+import Editor from "@/components/Editor";
+
 export default function Home() {
   return (
-    <div className="flex flex-col items-center justify-center h-screen font-[family-name:var(--font-noto-sans)]">
-      <h1 className="text-4xl font-normal text-neutral-400">
-        What&apos;s on your mind?
-      </h1>
+    <div className="flex flex-col items-center min-h-screen font-[family-name:var(--font-noto-sans)]">
+      <div className="w-full px-4 md:px-0 md:w-[640px] flex-1 mt-[40vh]">
+        <Editor />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### TL;DR

Replace static heading with Editor component on homepage

### What changed?

- Imported the `Editor` component from components directory
- Replaced the static "What's on your mind?" heading with the `Editor` component
- Updated layout styling:
  - Changed from `h-screen` to `min-h-screen` for better content handling
  - Added responsive padding (4px on mobile, 0px on md breakpoint)
  - Set width to full on mobile and 640px on md breakpoint
  - Added top margin of 40vh to position the editor

### How to test?

1. Run the application locally
2. Verify the Editor component appears on the homepage
3. Check that the responsive layout works correctly on both mobile and desktop viewports
4. Confirm the editor is positioned correctly with appropriate top margin

### Why make this change?

This change implements the actual editor functionality on the homepage instead of just displaying a static heading. It improves the user experience by providing an interactive editor while maintaining a clean, responsive layout across different device sizes.