### PR TITLE
style: change editor placement

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import Editor from "@/components/Editor";
 export default function Home() {
   return (
     <div className="flex flex-col items-center min-h-screen font-[family-name:var(--font-noto-sans)]">
-      <div className="w-full px-4 md:px-0 md:w-[640px] flex-1 mt-[40vh]">
+      <div className="w-full px-4 md:px-0 lg:w-3/5 flex-1 mt-[30vh]">
         <Editor />
       </div>
     </div>


### PR DESCRIPTION
### TL;DR

Adjusted the layout dimensions for better responsiveness across different screen sizes.

### What changed?

- Modified the container width from a fixed `md:w-[640px]` to a responsive `lg:w-3/5` for large screens
- Reduced the top margin from `mt-[40vh]` to `mt-[30vh]` to improve vertical positioning

### How to test?

1. Open the application in different screen sizes (mobile, tablet, desktop)
2. Verify that the editor container is:
   - Full width with padding on mobile
   - Full width with no padding on medium screens
   - 60% width on large screens
3. Confirm the editor now starts at 30% from the top of the viewport instead of 40%

### Why make this change?

This change improves the responsive layout by:
- Using relative width (3/5 or 60%) instead of fixed width on large screens for better adaptability
- Reducing the top margin to provide more vertical space for the editor content
- Maintaining a consistent user experience across different device sizes