### PR TITLE
feat: configure placeholder text in editor

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -6,18 +6,8 @@ import { defaultExtensions } from "@/lib/extensions";
 
 const extensions = [...defaultExtensions];
 
-const defaultContent = {
-  type: "doc",
-  content: [
-    {
-      type: "paragraph",
-      content: [{ type: "text", text: "What's on your mind?" }],
-    },
-  ],
-};
-
 const Editor = () => {
-  const [content, setContent] = useState<JSONContent | null>(defaultContent);
+  const [content, setContent] = useState<JSONContent | null>(null);
 
   return (
     <div className="h-full">

--- a/src/lib/extensions.ts
+++ b/src/lib/extensions.ts
@@ -11,10 +11,10 @@ import {
 
 import { cx } from "class-variance-authority";
 
-// TODO I am using cx here to get tailwind autocomplete working, idk if someone else can write a regex to just capture the class key in objects
+const placeholder = Placeholder.configure({
+  placeholder: "What's on your mind?",
+});
 
-// You can overwrite the placeholder with your own configuration
-const placeholder = Placeholder;
 const tiptapLink = TiptapLink.configure({
   HTMLAttributes: {
     class: cx(


### PR DESCRIPTION
### TL;DR

Configured the editor placeholder text properly and removed the default content.

### What changed?

- Removed the hardcoded default content from the Editor component
- Properly configured the Placeholder extension with "What's on your mind?" text
- Changed the initial state of content from having default text to being null

### How to test?

1. Open the editor component
2. Verify that "What's on your mind?" appears as placeholder text when the editor is empty
3. Confirm that the placeholder disappears when you start typing
4. Check that the editor starts empty rather than with pre-filled content

### Why make this change?

This change improves the user experience by using the proper placeholder functionality instead of pre-filling the editor with content that users would need to delete. Using the Placeholder extension is the correct approach for showing hint text that automatically disappears when users begin typing.