### PR TITLE
style: replace Noto Sans with Lato font

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-noto-sans);
+  --font-lato: var(--font-lato);
 
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
-import { Noto_Sans } from "next/font/google";
+import { Lato } from "next/font/google";
 import "./globals.css";
 import "./prosemirror.css";
 
-const notoSans = Noto_Sans({
-  variable: "--font-noto-sans",
+const lato = Lato({
+  variable: "--font-lato",
   subsets: ["latin"],
+  weight: ["100", "300", "400", "700", "900"],
 });
 
 export const metadata: Metadata = {
@@ -20,7 +21,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${notoSans.variable} antialiased`}>{children}</body>
+      <body className={`${lato.variable} antialiased`}>{children}</body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import Editor from "@/components/Editor";
 
 export default function Home() {
   return (
-    <div className="flex flex-col items-center min-h-screen font-[family-name:var(--font-noto-sans)]">
+    <div className="flex flex-col items-center min-h-screen font-[family-name:var(--font-lato)]">
       <div className="w-full px-4 md:px-0 lg:w-3/5 flex-1 mt-[30vh]">
         <Editor />
       </div>

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -24,7 +24,7 @@ const Editor = () => {
           editorProps={{
             attributes: {
               class:
-                "prose prose-sm sm:prose lg:prose-lg xl:prose-2xl mx-auto border-none font-[family-name:var(--font-noto-sans)]",
+                "prose prose-sm sm:prose lg:prose-lg xl:prose-2xl mx-auto border-none font-[family-name:var(--font-lato)]",
             },
           }}
         />


### PR DESCRIPTION
### TL;DR

Changed the application font from Noto Sans to Lato.

### What changed?

- Replaced Noto Sans with Lato as the primary font throughout the application
- Added multiple font weights for Lato (100, 300, 400, 700, 900) to provide more typography options
- Updated all CSS variable references from `--font-noto-sans` to `--font-lato`
- Modified font family references in the main layout, page, and Editor component

### How to test?

1. Run the application and verify that the font has changed to Lato
2. Check that the text appears correctly across different components
3. Ensure that various font weights render properly where applied

### Why make this change?

Lato provides a more modern and versatile typography option with multiple weight variants, which allows for better visual hierarchy and design flexibility. The additional font weights (thin, light, regular, bold, and black) enable more nuanced typography throughout the application.