### PR TITLE
fix: use proper tiptap link

### DIFF
--- a/src/lib/extensions.ts
+++ b/src/lib/extensions.ts
@@ -84,7 +84,7 @@ const starterKit = StarterKit.configure({
 export const defaultExtensions = [
   starterKit,
   placeholder,
-  TiptapLink,
+  tiptapLink,
   TiptapImage,
   UpdatedImage,
   taskList,


### PR DESCRIPTION
### TL;DR

Fixed a case inconsistency in the TiptapLink import reference.

### What changed?

Changed the reference from `TiptapLink` to `tiptapLink` in the `defaultExtensions` array in `src/lib/extensions.ts`. This corrects a case mismatch that likely caused import errors.

### How to test?

1. Verify that the editor loads correctly with link functionality
2. Try creating and editing links in the editor to ensure the link extension works properly
3. Check that there are no console errors related to the TiptapLink extension

### Why make this change?

This change ensures consistency between the imported variable name and its usage. The incorrect casing likely caused runtime errors or prevented the link extension from functioning properly. This fix maintains code quality and prevents potential bugs.