### PR TITLE
fix: placeholder appears when not empty

### DIFF
--- a/src/lib/extensions.ts
+++ b/src/lib/extensions.ts
@@ -13,6 +13,8 @@ import { cx } from "class-variance-authority";
 
 const placeholder = Placeholder.configure({
   placeholder: "What's on your mind?",
+  emptyEditorClass: "is-editor-empty",
+  emptyNodeClass: "is-editor-empty",
 });
 
 const tiptapLink = TiptapLink.configure({


### PR DESCRIPTION
### TL;DR

Added empty editor and node classes to the Placeholder configuration in the TipTap editor.

### What changed?

Added two new configuration properties to the Placeholder extension:
- `emptyEditorClass: "is-editor-empty"`
- `emptyNodeClass: "is-editor-empty"`

These classes will be applied to the editor and nodes when they are empty.

### How to test?

1. Open the editor component
2. Clear all content from the editor
3. Verify that the `is-editor-empty` class is applied to both the editor and empty nodes
4. Add content and verify the class is removed

### Why make this change?

This change enables better styling control for empty editor states. By adding these classes, we can apply specific CSS styles when the editor is empty, improving the visual feedback for users and making it easier to distinguish between empty and filled states.