### PR TITLE
style: remove unused css

### DIFF
--- a/src/app/prosemirror.css
+++ b/src/app/prosemirror.css
@@ -60,63 +60,6 @@
   }
 }
 
-/* Custom TODO list checkboxes – shoutout to this awesome tutorial: https://moderncss.dev/pure-css-custom-checkbox-style/ */
-ul[data-type="taskList"] li > label {
-  margin-right: 0.2rem;
-  user-select: none;
-}
-
-@media screen and (max-width: 768px) {
-  ul[data-type="taskList"] li > label {
-    margin-right: 0.5rem;
-  }
-}
-
-ul[data-type="taskList"] li > label input[type="checkbox"] {
-  -webkit-appearance: none;
-  appearance: none;
-  background-color: hsl(var(--background));
-  margin: 0;
-  cursor: pointer;
-  width: 1.2em;
-  height: 1.2em;
-  position: relative;
-  top: 5px;
-  border: 2px solid hsl(var(--border));
-  margin-right: 0.3rem;
-  display: grid;
-  place-content: center;
-
-  &:hover {
-    background-color: hsl(var(--accent));
-  }
-
-  &:active {
-    background-color: hsl(var(--accent));
-  }
-
-  &::before {
-    content: "";
-    width: 0.65em;
-    height: 0.65em;
-    transform: scale(0);
-    transition: 120ms transform ease-in-out;
-    box-shadow: inset 1em 1em;
-    transform-origin: center;
-    clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
-  }
-
-  &:checked::before {
-    transform: scale(1);
-  }
-}
-
-ul[data-type="taskList"] li[data-checked="true"] > div > p {
-  color: var(--muted-foreground);
-  text-decoration: line-through;
-  text-decoration-thickness: 2px;
-}
-
 /* Overwrite tippy-box original max-width */
 .tippy-box {
   max-width: 400px !important;


### PR DESCRIPTION
### TL;DR

Removed custom CSS styling for task list checkboxes from the ProseMirror stylesheet.

### What changed?

Removed all CSS related to custom task list checkboxes, including:
- Styling for checkbox labels
- Custom checkbox appearance with hover and active states
- Checkbox check mark animation
- Styling for completed task items (strikethrough and color change)

The removed code also included responsive styling for mobile devices and referenced a tutorial from moderncss.dev.

### How to test?

1. Open the application and create or view a document with task lists
2. Verify that task lists still function correctly but now use default checkbox styling
3. Check the appearance on both desktop and mobile views
4. Ensure that completed tasks are visually distinguishable from uncompleted ones

### Why make this change?

This change likely simplifies the codebase by removing custom styling that may have been redundant or replaced by a different implementation. It could be part of a larger effort to standardize UI components or move checkbox styling to a component library.