### PR TITLE
feat: remove titlebar text

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "write",
+        "title": "",
         "width": 1280,
         "height": 720,
         "resizable": true,


### PR DESCRIPTION
### TL;DR

Removed the default window title from the Tauri configuration.

### What changed?

Changed the window title in `src-tauri/tauri.conf.json` from "write" to an empty string.

### How to test?

1. Launch the application
2. Verify that the window no longer displays "write" in the title bar
3. Confirm that the title bar appears as expected with an empty title

### Why make this change?

Removing the default window title provides a cleaner user interface and allows for dynamic title setting through the application code rather than having a static title defined in the configuration.