### PR TITLE
feat: add command menu with keyboard shortcut

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+import { useEffect } from "react";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "./ui/command";
+
+const CommandMenu = () => {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const down = (event: KeyboardEvent) => {
+      if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        setOpen((open) => !open);
+      }
+    };
+
+    document.addEventListener("keydown", down);
+    return () => document.removeEventListener("keydown", down);
+  }, []);
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandInput placeholder="Type a command or search..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Suggestions">
+          <CommandItem>Save</CommandItem>
+          <CommandItem>Chat</CommandItem>
+          <CommandItem>Export</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+};
+
+export default CommandMenu;


### PR DESCRIPTION
### TL;DR

Added a new CommandMenu component with keyboard shortcut functionality.

### What changed?

Created a new `CommandMenu.tsx` component that implements a command palette interface. The component includes:
- A command dialog that can be toggled with Cmd/Ctrl+K keyboard shortcut
- Command input field with search placeholder
- Empty state message when no results are found
- A suggestions group with sample command items (Save, Chat, Export)
- Proper event listener cleanup in the useEffect hook

### How to test?

1. Press Cmd+K (Mac) or Ctrl+K (Windows/Linux) to open the command menu
2. Verify the command dialog appears with the input field and suggestion items
3. Type in the search field to test filtering
4. Press Escape or click outside the dialog to close it
5. Press the keyboard shortcut again to confirm it reopens

### Why make this change?

Adding a command palette improves application accessibility and efficiency by providing keyboard-driven navigation. This pattern is popular in modern applications as it allows users to quickly access functionality without navigating through menus, enhancing the overall user experience.