### PR TITLE
feat: add CommandMenu to root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Lato } from "next/font/google";
 import "./globals.css";
 import "./prosemirror.css";
+import CommandMenu from "@/components/CommandMenu";
 
 const lato = Lato({
   variable: "--font-lato",
@@ -21,7 +22,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${lato.variable} antialiased`}>{children}</body>
+      <body className={`${lato.variable} antialiased`}>
+        <CommandMenu />
+        {children}
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
### TL;DR

Added a CommandMenu component to the root layout.

### What changed?

- Imported the CommandMenu component from `@/components/CommandMenu`
- Added the CommandMenu component to the body element in the RootLayout, ensuring it appears on all pages of the application

### How to test?

1. Run the application
2. Verify that the CommandMenu appears on all pages
3. Test the functionality of the CommandMenu to ensure it works as expected

### Why make this change?

This change adds a command menu to the application, providing users with a consistent interface for executing commands throughout the application. The CommandMenu is placed at the root layout level to ensure it's available across all pages.