### PR TITLE
feat: add TipText component for command menu shortcut

### DIFF
--- a/src/components/TipText.tsx
+++ b/src/components/TipText.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const TipText = () => {
+  const [isMac, setIsMac] = useState(false);
+
+  useEffect(() => {
+    setIsMac(/Mac|iPhone|iPod|iPad/.test(navigator.userAgent));
+  }, []);
+
+  return (
+    <div className="fixed bottom-4 left-4 text-sm text-muted-foreground animate-in fade-in slide-in-from-bottom-4 duration-1000">
+      Press {isMac ? "⌘" : "Ctrl"} + K to open command menu
+    </div>
+  );
+};
+
+export default TipText;


### PR DESCRIPTION
### TL;DR

Added a new TipText component that displays a keyboard shortcut hint at the bottom of the screen.

### What changed?

Created a new React component `TipText.tsx` that shows a small text prompt at the bottom left of the screen, informing users they can press Cmd+K (on Mac) or Ctrl+K (on other platforms) to open the command menu. The component:
- Uses client-side rendering with the "use client" directive
- Detects the user's operating system via the user agent
- Displays the appropriate keyboard shortcut symbol (⌘ or Ctrl)
- Includes a subtle animation when appearing

### How to test?

1. Run the application in a browser
2. Verify the tip text appears at the bottom left corner
3. Test on both Mac and non-Mac devices to ensure the correct keyboard shortcut is displayed
4. Check that the animation works correctly

### Why make this change?

This improves user experience by providing a visual hint about the command menu shortcut, making the feature more discoverable. The platform-specific detection ensures users see the correct keyboard shortcut for their device.