### PR TITLE
feat: add TipText component to root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Lato } from "next/font/google";
 import "./globals.css";
 import "./prosemirror.css";
 import CommandMenu from "@/components/CommandMenu";
+import TipText from "@/components/TipText";
 
 const lato = Lato({
   variable: "--font-lato",
@@ -24,6 +25,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${lato.variable} antialiased`}>
         <CommandMenu />
+        <TipText />
         {children}
       </body>
     </html>


### PR DESCRIPTION
### TL;DR

Added a new `TipText` component to the root layout.

### What changed?

- Imported the `TipText` component from `@/components/TipText`
- Added the `<TipText />` component to the body section of the root layout, alongside the existing `CommandMenu` component

### How to test?

1. Run the application
2. Verify that the `TipText` component renders correctly on all pages
3. Check that it doesn't interfere with other UI elements or the `CommandMenu` component

### Why make this change?

The `TipText` component likely provides helpful tips or guidance to users throughout the application. Adding it to the root layout ensures it's consistently available across all pages, improving the overall user experience.