### PR TITLE
fix: hide TipText on mobile devices

### DIFF
--- a/src/components/TipText.tsx
+++ b/src/components/TipText.tsx
@@ -10,7 +10,7 @@ const TipText = () => {
   }, []);
 
   return (
-    <div className="fixed bottom-4 left-4 text-sm text-muted-foreground animate-in fade-in slide-in-from-bottom-4 duration-1000">
+    <div className="fixed bottom-4 left-4 text-sm text-muted-foreground animate-in fade-in slide-in-from-bottom-4 duration-1000 hidden sm:block">
       Press {isMac ? "⌘" : "Ctrl"} + K to open command menu
     </div>
   );


### PR DESCRIPTION
### TL;DR

Hide the command menu tip text on small screens.

### What changed?

Added the `hidden sm:block` Tailwind classes to the tip text component that shows the keyboard shortcut for opening the command menu. This hides the tip on mobile/small screens and only displays it on screens that are at least the "sm" breakpoint size.

### How to test?

1. Open the application on a desktop browser and verify the command menu tip is visible
2. Resize the browser window to a small/mobile size (less than the "sm" breakpoint)
3. Confirm the tip text disappears on small screens

### Why make this change?

The command menu tip is less relevant on mobile devices where keyboard shortcuts aren't typically used. Hiding it on small screens improves the mobile UI by reducing clutter while maintaining the helpful tip for desktop users.