### PR TITLE
feat: setup transparent titlebar

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,6 @@
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
+use tauri::{TitleBarStyle, WebviewUrl, WebviewWindowBuilder};
+
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -10,6 +12,28 @@ pub fn run() {
                         .build(),
                 )?;
             }
+
+            let win_builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
+                .title("")
+                .inner_size(1100.0, 700.0);
+
+            #[cfg(target_os = "macos")]
+            let win_builder = win_builder.title_bar_style(TitleBarStyle::Transparent);
+
+            let window = win_builder.build().unwrap();
+
+            #[cfg(target_os = "macos")]
+            {
+                use cocoa::appkit::{NSColor, NSWindow};
+                use cocoa::base::{id, nil};
+
+                let ns_window = window.ns_window().unwrap() as id;
+                unsafe {
+                    let bg_color = NSColor::colorWithRed_green_blue_alpha_(nil, 1.0, 1.0, 1.0, 1.0);
+                    ns_window.setBackgroundColor_(bg_color);
+                }
+            }
+
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,15 +10,7 @@
     "beforeBuildCommand": "pnpm build"
   },
   "app": {
-    "windows": [
-      {
-        "title": "",
-        "width": 1280,
-        "height": 720,
-        "resizable": true,
-        "fullscreen": false
-      }
-    ],
+    "windows": [],
     "security": {
       "csp": null
     }


### PR DESCRIPTION
### TL;DR

Implemented custom window creation with transparent title bar for macOS.

### What changed?

- Removed the window configuration from `tauri.conf.json`
- Added programmatic window creation in `lib.rs` using `WebviewWindowBuilder`
- Implemented macOS-specific customization with transparent title bar
- Set white background color for macOS windows using Cocoa APIs
- Adjusted default window size to 1100x700

### How to test?

1. Run the application on macOS to verify the transparent title bar works correctly
2. Check that the window has the correct size (1100x700)
3. Verify the window background is white on macOS
4. Ensure the application still works correctly on non-macOS platforms

### Why make this change?

This change provides a more native and polished look on macOS by implementing a transparent title bar, which better integrates with the macOS UI. By moving window creation to code rather than configuration, we gain more control over platform-specific window styling and can apply conditional customizations based on the operating system.