### PR TITLE
refactor: move window management

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-use tauri::{TitleBarStyle, WebviewUrl, WebviewWindowBuilder};
+mod window;
 
 pub fn run() {
     tauri::Builder::default()
@@ -13,26 +13,7 @@ pub fn run() {
                 )?;
             }
 
-            let win_builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
-                .title("")
-                .inner_size(1100.0, 700.0);
-
-            #[cfg(target_os = "macos")]
-            let win_builder = win_builder.title_bar_style(TitleBarStyle::Transparent);
-
-            let window = win_builder.build().unwrap();
-
-            #[cfg(target_os = "macos")]
-            {
-                use cocoa::appkit::{NSColor, NSWindow};
-                use cocoa::base::{id, nil};
-
-                let ns_window = window.ns_window().unwrap() as id;
-                unsafe {
-                    let bg_color = NSColor::colorWithRed_green_blue_alpha_(nil, 1.0, 1.0, 1.0, 1.0);
-                    ns_window.setBackgroundColor_(bg_color);
-                }
-            }
+            window::create_main_window(app)?;
 
             Ok(())
         })

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -1,0 +1,26 @@
+use tauri::{App, TitleBarStyle, WebviewUrl, WebviewWindowBuilder};
+
+pub fn create_main_window(app: &mut App) -> tauri::Result<()> {
+    let win_builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
+        .title("")
+        .inner_size(1100.0, 700.0);
+
+    #[cfg(target_os = "macos")]
+    let win_builder = win_builder.title_bar_style(TitleBarStyle::Transparent);
+
+    let window = win_builder.build().unwrap();
+
+    #[cfg(target_os = "macos")]
+    {
+        use cocoa::appkit::{NSColor, NSWindow};
+        use cocoa::base::{id, nil};
+
+        let ns_window = window.ns_window().unwrap() as id;
+        unsafe {
+            let bg_color = NSColor::colorWithRed_green_blue_alpha_(nil, 1.0, 1.0, 1.0, 1.0);
+            ns_window.setBackgroundColor_(bg_color);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### TL;DR

Refactored window creation logic into a separate module for better code organization.

### What changed?

- Created a new `window.rs` module to encapsulate window creation functionality
- Moved the window creation logic from `lib.rs` into a dedicated `create_main_window` function
- Updated the main application code to use this new function

### How to test?

1. Build and run the application
2. Verify that the main window appears with the correct size (1100x700)
3. On macOS, confirm that the transparent title bar is working correctly
4. Ensure the window background color is properly set on macOS

### Why make this change?

This refactoring improves code organization by separating window creation logic into its own module, making the codebase more maintainable. It follows the single responsibility principle by isolating window-specific code, which will make future window-related changes easier to implement.