### PR TITLE
chore: update product name and app identifier

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-  "productName": "write",
+  "productName": "Write",
   "version": "0.1.0",
-  "identifier": "com.tauri.dev",
+  "identifier": "com.write.app",
   "build": {
     "frontendDist": "../out",
     "devUrl": "http://localhost:3000",


### PR DESCRIPTION
### TL;DR

Updated application branding in Tauri configuration.

### What changed?

- Changed the `productName` from "write" to "Write" (capitalized first letter)
- Updated the `identifier` from "com.tauri.dev" to "com.write.app"

### How to test?

1. Build the application with the updated configuration
2. Verify that the application name appears as "Write" in the OS
3. Confirm the bundle identifier is correctly set to "com.write.app"

### Why make this change?

This change establishes proper branding for the application by using the correct capitalization for the product name and setting an appropriate application identifier that reflects the product's identity rather than using the default Tauri development identifier.