### PR TITLE
style: adjust editor prose responsive breakpoints

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -24,7 +24,7 @@ const Editor = () => {
           editorProps={{
             attributes: {
               class:
-                "prose prose-sm sm:prose lg:prose-lg xl:prose-2xl mx-auto border-none font-[family-name:var(--font-lato)]",
+                "prose prose md:prose-lg xl:prose-2xl mx-auto border-none font-[family-name:var(--font-lato)]",
             },
           }}
           immediatelyRender={false}


### PR DESCRIPTION
### TL;DR

Updated responsive typography sizing in the editor component.

### What changed?

Modified the Tailwind CSS classes for the editor's typography:
- Removed `prose-sm` class
- Changed `sm:prose` to `prose`
- Changed `lg:prose-lg` to `md:prose-lg`
- Kept `xl:prose-2xl` unchanged

### How to test?

1. Open the editor component in various viewport sizes
2. Verify the text sizing appears correctly at:
   - Default/mobile view
   - Medium (md) breakpoint
   - Extra large (xl) breakpoint
3. Confirm the typography scales appropriately between breakpoints

### Why make this change?

This change improves the responsive typography scaling of the editor by:
- Using the default `prose` size for small screens instead of `prose-sm`
- Starting the larger text size (`prose-lg`) at medium breakpoints instead of large breakpoints
- Creating a more consistent reading experience across different device sizes