### PR TITLE
feat: add dexie and dexie-react-hooks dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "dexie": "^4.0.11",
+    "dexie-react-hooks": "^1.1.7",
     "lucide-react": "^0.488.0",
     "next": "15.3.0",
     "novel": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      dexie:
+        specifier: ^4.0.11
+        version: 4.0.11
+      dexie-react-hooks:
+        specifier: ^1.1.7
+        version: 1.1.7(@types/react@19.1.1)(dexie@4.0.11)(react@19.1.0)
       lucide-react:
         specifier: ^0.488.0
         version: 0.488.0(react@19.1.0)
@@ -1354,6 +1360,16 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dexie-react-hooks@1.1.7:
+    resolution: {integrity: sha512-Lwv5W0Hk+uOW3kGnsU9GZoR1er1B7WQ5DSdonoNG+focTNeJbHW6vi6nBoX534VKI3/uwHebYzSw1fwY6a7mTw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      dexie: ^3.2 || ^4.0.1-alpha
+      react: '>=16'
+
+  dexie@4.0.11:
+    resolution: {integrity: sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -3981,6 +3997,14 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  dexie-react-hooks@1.1.7(@types/react@19.1.1)(dexie@4.0.11)(react@19.1.0):
+    dependencies:
+      '@types/react': 19.1.1
+      dexie: 4.0.11
+      react: 19.1.0
+
+  dexie@4.0.11: {}
 
   doctrine@2.1.0:
     dependencies:


### PR DESCRIPTION
### TL;DR

Added Dexie.js and Dexie React Hooks to the project dependencies.

### What changed?

- Added `dexie` v4.0.11 to package.json dependencies
- Added `dexie-react-hooks` v1.1.7 to package.json dependencies
- Updated pnpm-lock.yaml with the new dependencies and their peer dependencies

### How to test?

1. Run `pnpm install` to install the new dependencies
2. Verify that Dexie.js and Dexie React Hooks can be imported in the project
3. Test any IndexedDB functionality that will be implemented using these libraries

### Why make this change?

Dexie.js is a wrapper for IndexedDB that simplifies database operations in the browser with a clean API. The addition of Dexie React Hooks will allow for reactive database queries in React components, enabling efficient client-side storage and retrieval of data without requiring server roundtrips for certain operations.