### PR TITLE
feat: create editor store with document ID management

### DIFF
--- a/src/store/useEditorStore.ts
+++ b/src/store/useEditorStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+type EditorStore = {
+  documentId: string | null;
+  setDocumentId: (documentId: string) => void;
+};
+
+const useEditorStore = create<EditorStore>((set) => ({
+  documentId: null,
+  setDocumentId: (documentId) => set({ documentId }),
+}));
+
+export { useEditorStore };


### PR DESCRIPTION
### TL;DR

Created a new editor store using Zustand to manage document state.

### What changed?

Added a new file `src/store/useEditorStore.ts` that implements a Zustand store to track the currently active document. The store provides:
- A `documentId` state property that holds the current document ID or null
- A `setDocumentId` action to update the document ID

### How to test?

1. Import the store in a component: `import { useEditorStore } from 'src/store/useEditorStore'`
2. Access the current document ID: `const { documentId } = useEditorStore()`
3. Set a new document ID: `useEditorStore.getState().setDocumentId('new-doc-123')`
4. Verify the state updates correctly across components that subscribe to this store

### Why make this change?

This store provides a centralized way to manage the currently active document across the application. Using Zustand allows for efficient state management with minimal re-renders and a simple API for components to access and update the document context.