### PR TITLE
build: add lodash debounce

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cmdk": "^1.1.1",
     "dexie": "^4.0.11",
     "dexie-react-hooks": "^1.1.7",
+    "lodash.debounce": "^4.0.8",
     "lucide-react": "^0.488.0",
     "nanoid": "^5.1.5",
     "next": "15.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       dexie-react-hooks:
         specifier: ^1.1.7
         version: 1.1.7(@types/react@19.1.1)(dexie@4.0.11)(react@19.1.0)
+      lodash.debounce:
+        specifier: ^4.0.8
+        version: 4.0.8
       lucide-react:
         specifier: ^0.488.0
         version: 0.488.0(react@19.1.0)
@@ -1990,6 +1993,9 @@ packages:
 
   lodash.castarray@4.4.0:
     resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
+
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
@@ -4778,6 +4784,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.castarray@4.4.0: {}
+
+  lodash.debounce@4.0.8: {}
 
   lodash.isplainobject@4.0.6: {}
 


### PR DESCRIPTION
### TL;DR

Added lodash.debounce dependency to the project.

### What changed?

Added the `lodash.debounce` package (version 4.0.8) to the project dependencies in both package.json and pnpm-lock.yaml files.

### How to test?

1. Run `pnpm install` to ensure the dependency is properly installed
2. Import and use the debounce function in your code:
   ```javascript
   import debounce from 'lodash.debounce';
   
   const debouncedFunction = debounce(() => {
     // Your function logic here
   }, 300); // 300ms delay
   ```
3. Verify the debounced function works as expected in your application

### Why make this change?

The lodash.debounce utility helps limit the rate at which a function can fire, which is useful for performance optimization in scenarios like:
- Search input handling
- Window resize events
- Scroll events
- API calls triggered by user input

This will help improve application performance by preventing excessive function calls in rapid succession.