### PR TITLE
refactor: remove duplicate TiptapImage extension

### DIFF
--- a/src/lib/extensions.ts
+++ b/src/lib/extensions.ts
@@ -1,5 +1,4 @@
 import {
-  TiptapImage,
   TiptapLink,
   UpdatedImage,
   TaskList,
@@ -87,7 +86,6 @@ export const defaultExtensions = [
   starterKit,
   placeholder,
   tiptapLink,
-  TiptapImage,
   UpdatedImage,
   taskList,
   taskItem,


### PR DESCRIPTION
### TL;DR

Removed the `TiptapImage` extension from the editor configuration.

### What changed?

Removed the import and usage of the `TiptapImage` extension from `src/lib/extensions.ts`. The `UpdatedImage` extension remains in place, suggesting that it's now the sole image handling extension.

### How to test?

1. Open the editor and verify that image functionality still works correctly
2. Insert images into the editor and confirm they display properly
3. Check that any image-related features (resizing, captions, etc.) function as expected

### Why make this change?

This change likely consolidates image handling to use only the `UpdatedImage` extension, removing redundancy and potential conflicts between multiple image extensions. The `UpdatedImage` extension probably provides all the necessary image functionality, making `TiptapImage` unnecessary.