### PR TITLE
build: disable eslint

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,7 @@ const nextConfig: NextConfig = {
     unoptimized: true,
   },
   assetPrefix: isProduction ? undefined : `http://${internalHost}:3000`,
+  ignoreDuringBuilds: true,
 };
 
 export default nextConfig;


### PR DESCRIPTION
### TL;DR

Added `ignoreDuringBuilds: true` to Next.js configuration.

### What changed?

Added the `ignoreDuringBuilds: true` flag to the Next.js configuration in `next.config.ts`. This setting tells Next.js to ignore TypeScript errors during the build process.

### How to test?

1. Run a build with TypeScript errors present
2. Verify that the build completes successfully despite the errors
3. Confirm that the application still functions as expected

### Why make this change?

This change allows builds to complete even when there are TypeScript errors present. This is useful in development environments or when migrating code, as it prevents TypeScript errors from blocking deployments while the team works on fixing them. It prioritizes shipping working code over strict type checking during the build process.