### PR TITLE
build: remove eslint dependency and ignoreDuringBuilds flag

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,6 @@ const nextConfig: NextConfig = {
     unoptimized: true,
   },
   assetPrefix: isProduction ? undefined : `http://${internalHost}:3000`,
-  ignoreDuringBuilds: true,
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "eslint": "^9",
     "eslint-config-next": "15.3.0",
     "tailwindcss": "^4",
     "typescript": "^5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,9 +84,6 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.1.2(@types/react@19.1.1)
-      eslint:
-        specifier: ^9
-        version: 9.24.0(jiti@2.4.2)
       eslint-config-next:
         specifier: 15.3.0
         version: 15.3.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)


### PR DESCRIPTION
### TL;DR

Removed unnecessary dependencies and configuration options from the project.

### What changed?

- Removed `ignoreDuringBuilds: true` from `next.config.ts`
- Removed `eslint` from direct dependencies in `package.json` (it's still available through `eslint-config-next`)
- Updated `pnpm-lock.yaml` to reflect the dependency changes

### How to test?

1. Run `pnpm install` to update dependencies
2. Verify that the build process works correctly with `pnpm build`
3. Ensure linting still functions properly with `pnpm lint`

### Why make this change?

The `ignoreDuringBuilds` flag was unnecessary in the Next.js configuration. Additionally, ESLint is already included as a transitive dependency through `eslint-config-next`, making the direct dependency redundant. This change helps streamline the project configuration and dependency management.