### PR TITLE
build: ignore ESLint during builds

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,9 @@ const nextConfig: NextConfig = {
     unoptimized: true,
   },
   assetPrefix: isProduction ? undefined : `http://${internalHost}:3000`,
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
### TL;DR

Disabled ESLint checks during Next.js builds by setting `ignoreDuringBuilds` to true.

### What changed?

Added an `eslint` configuration object to `next.config.ts` with the `ignoreDuringBuilds` property set to `true`. This prevents ESLint from running during the build process.

### How to test?

1. Run a Next.js build with `npm run build` or `yarn build`
2. Verify that ESLint errors no longer block the build process
3. Confirm that the application still builds successfully even with ESLint issues present

### Why make this change?

This change allows builds to complete successfully even when there are ESLint warnings or errors. This is useful for development environments or when you want to separate the linting process from the build process, making builds faster and preventing them from failing due to code style issues.