### PR TITLE
feat: add saving to editor

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { EditorContent, EditorRoot, JSONContent } from "novel";
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { defaultExtensions } from "@/lib/extensions";
 import { useEditorStore } from "@/store/useEditorStore";
 import { nanoid } from "nanoid";
 import debounce from "lodash.debounce";
+import { getDocument, saveDocument } from "@/lib/db";
 
 const extensions = [...defaultExtensions];
 
@@ -17,11 +18,12 @@ const Editor = () => {
   const debouncedSave = useCallback(
     debounce((json: JSONContent) => {
       if (!documentId) {
-        // console.log("no document id");
+        console.log("no document id");
         return;
       }
 
-      // console.log("saved document");
+      saveDocument(documentId, json, Date.now());
+      console.log("saved document");
     }, 1000),
     [documentId]
   );


### PR DESCRIPTION
### TL;DR

Implemented document saving functionality in the Editor component.

### What changed?

- Added imports for `useEffect`, `useState`, and database functions (`getDocument`, `saveDocument`)
- Updated the `debouncedSave` callback to actually save documents to the database using the `saveDocument` function
- Uncommented and enabled console logging for debugging document saves

### How to test?

1. Open the editor and make changes to a document
2. Wait for the debounce period (1000ms)
3. Verify in the console that "saved document" is logged
4. Check the database to confirm the document was saved with the correct ID and content

### Why make this change?

This change implements the core document persistence functionality, allowing user edits to be saved to the database automatically. Without this, any changes made in the editor would be lost when the user navigates away or refreshes the page.