### PR TITLE
feat: add skeleton component

### DIFF
--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
### TL;DR

Added a new Skeleton UI component for loading states.

### What changed?

Created a new `Skeleton` component in `src/components/ui/skeleton.tsx` that renders a div with animation and styling for loading placeholders. The component:
- Uses the `cn` utility for class name composition
- Applies `bg-accent` and `animate-pulse` classes by default
- Includes a `data-slot="skeleton"` attribute for targeting
- Accepts and forwards all standard div props
- Allows custom class names to be merged with the default styles

### How to test?

1. Import the Skeleton component in any view:
   ```jsx
   import { Skeleton } from "@/components/ui/skeleton";
   ```

2. Use it in place of content that's loading:
   ```jsx
   <Skeleton className="h-12 w-full" />
   ```

3. Verify that it displays a pulsing placeholder with rounded corners

### Why make this change?

To provide a consistent loading state component across the application, improving user experience by indicating when content is being loaded. This reduces perceived wait times and provides visual feedback to users during asynchronous operations.