### PR TITLE
feat: add in skeleton loading state

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -8,6 +8,8 @@ import { nanoid } from "nanoid";
 import debounce from "lodash.debounce";
 import { getDocument, saveDocument } from "@/lib/db";
 
+import { Skeleton } from "@/components/ui/skeleton";
+
 const extensions = [...defaultExtensions];
 
 const MIN_WORDS = 5;
@@ -65,7 +67,19 @@ const Editor = () => {
   );
 
   if (!isLoaded) {
-    return <div className="h-full">Loading...</div>;
+    return (
+      <div className="h-full flex flex-col space-y-4 p-4">
+        <Skeleton className="h-8 w-3/4" />
+        <Skeleton className="h-8 w-1/2" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-4 w-4/5" />
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/4" />
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
### TL;DR

Enhanced the editor loading state with a skeleton UI instead of a simple "Loading..." text.

### What changed?

- Imported the `Skeleton` component from UI components
- Replaced the basic "Loading..." text with a structured skeleton UI
- Added multiple skeleton elements of varying widths to simulate document content loading

### How to test?

1. Open the editor component
2. Observe the loading state before content is fully loaded
3. Verify that the skeleton UI appears and properly represents the loading state of document content

### Why make this change?

This change improves the user experience during loading by providing visual feedback that mimics the actual content structure. The skeleton UI gives users a better indication of the loading progress compared to a simple text message, reducing perceived loading time and creating a more polished interface.