### PR TITLE
feat: add save notification

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -7,6 +7,7 @@ import { useEditorStore } from "@/store/useEditorStore";
 import { nanoid } from "nanoid";
 import debounce from "lodash.debounce";
 import { getDocument, saveDocument } from "@/lib/db";
+import { useNotificationContext } from "@/components/NotificationProvider";
 
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -17,6 +18,7 @@ const DEBOUNCE_TIME = 1000;
 
 const Editor = () => {
   const { documentId, setDocumentId } = useEditorStore();
+  const { showNotification } = useNotificationContext();
   const [initialContent, setInitialContent] = useState<JSONContent | undefined>(
     undefined
   );
@@ -47,8 +49,9 @@ const Editor = () => {
       }
 
       saveDocument(documentId, json, Date.now());
+      showNotification({ message: "Saved just now" });
     }, DEBOUNCE_TIME),
-    [documentId]
+    [documentId, showNotification]
   );
 
   const handleUpdate = useCallback(


### PR DESCRIPTION
### TL;DR

Added notification when document is saved in the Editor component.

### What changed?

- Imported the `useNotificationContext` hook from the NotificationProvider component
- Added the `showNotification` function from the context to the Editor component
- Added a notification with the message "Saved just now" after a document is saved
- Updated the dependency array in the `useCallback` to include the `showNotification` function

### How to test?

1. Open the editor and make changes to a document
2. Wait for the auto-save to trigger (after 1 second of inactivity)
3. Verify that a notification appears with the message "Saved just now"

### Why make this change?

This change provides users with visual feedback when their document is automatically saved, improving the user experience by confirming that their work is being preserved without requiring them to manually check.