### PR TITLE
feat: add document title support

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -43,12 +43,12 @@ const Editor = () => {
   }, [documentId]);
 
   const debouncedSave = useCallback(
-    debounce((json: JSONContent) => {
+    debounce((json: JSONContent, title: string) => {
       if (!documentId) {
         return;
       }
 
-      saveDocument(documentId, json, Date.now());
+      saveDocument(documentId, title, json, Date.now());
       showNotification({ message: "Saved just now" });
     }, DEBOUNCE_TIME),
     [documentId, showNotification]
@@ -56,15 +56,22 @@ const Editor = () => {
 
   const handleUpdate = useCallback(
     (json: JSONContent, text: string) => {
-      const wordCount = text.split(" ").length;
+      const words = text.split(" ").filter((word) => word.length > 0);
+      const wordCount = words.length;
 
       if (!documentId && wordCount > MIN_WORDS) {
         const newDocumentId = nanoid();
         setDocumentId(newDocumentId);
       }
 
-      if (documentId && wordCount > MIN_WORDS) {
-        debouncedSave(json);
+      if (documentId) {
+        if (wordCount < 1) {
+          debouncedSave(json, "");
+          return;
+        }
+
+        const title = words.slice(0, 5).join(" ");
+        debouncedSave(json, title);
       }
     },
     [documentId, setDocumentId, debouncedSave]

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -3,6 +3,7 @@ import type { JSONContent } from "novel";
 
 interface Document {
   id: string;
+  title: string;
   content: JSONContent;
   updatedAt: number;
 }
@@ -19,11 +20,13 @@ db.version(1).stores({
 
 const saveDocument = async (
   id: string,
+  title: string,
   content: JSONContent,
   updatedAt: number
 ) => {
   await db.documents.put({
     id,
+    title,
     content,
     updatedAt,
   });


### PR DESCRIPTION
### TL;DR

Added document titles to the editor and database schema.

### What changed?

- Modified the `saveDocument` function to accept a `title` parameter
- Updated the database schema to include a `title` field in the Document interface
- Enhanced the editor's save functionality to automatically generate titles from the first 5 words of content
- Improved word count calculation by filtering out empty strings
- Added special handling for empty documents

### How to test?

1. Create a new document with at least one word
2. Verify that a title is automatically generated from the first 5 words
3. Edit the document and confirm the title updates accordingly
4. Create an empty document and verify it handles the empty state correctly
5. Check that documents are properly saved with their titles in the database

### Why make this change?

This change improves document organization by automatically generating titles based on content, making it easier for users to identify and manage their documents. The title extraction logic provides a meaningful preview of document content without requiring manual title input from users.