### PR TITLE
feat: add getDocumentTitles function

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -44,5 +44,20 @@ const getAllDocuments = async () => {
   return await db.documents.orderBy("updatedAt").reverse().toArray();
 };
 
+const getDocumentTitles = async () => {
+  return await db.documents
+    .orderBy("updatedAt")
+    .reverse()
+    .toArray()
+    .then((documents) => documents.map(({ id, title }) => ({ id, title })));
+};
+
 export type { Document };
-export { db, saveDocument, getDocument, deleteDocument, getAllDocuments };
+export {
+  db,
+  saveDocument,
+  getDocument,
+  deleteDocument,
+  getAllDocuments,
+  getDocumentTitles,
+};


### PR DESCRIPTION
### TL;DR

Added a new `getDocumentTitles` function to retrieve only document IDs and titles.

### What changed?

- Created a new database function `getDocumentTitles()` that returns an array of objects containing only the `id` and `title` properties of documents
- The function orders documents by `updatedAt` in descending order (newest first)
- Added the new function to the module exports

### How to test?

1. Import the `getDocumentTitles` function in a component
2. Call the function and verify it returns only the ID and title for each document
3. Confirm the documents are ordered with the most recently updated first

### Why make this change?

This optimization allows components to fetch just document titles and IDs when the full document content isn't needed, reducing the amount of data transferred and improving performance for document listing views.