### PR TITLE
fix: handle case with no title

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -49,7 +49,12 @@ const getDocumentTitles = async () => {
     .orderBy("updatedAt")
     .reverse()
     .toArray()
-    .then((documents) => documents.map(({ id, title }) => ({ id, title })));
+    .then((documents) =>
+      documents.map(({ id, title }) => ({
+        id,
+        title: title === "" ? "Untitled" : title,
+      }))
+    );
 };
 
 export type { Document };


### PR DESCRIPTION
### TL;DR

Display "Untitled" for documents with empty titles in the document list.

### What changed?

Modified the `getDocumentTitles` function in `db.ts` to replace empty document titles with the text "Untitled" when retrieving document titles from the database.

### How to test?

1. Create a document with an empty title
2. Navigate to the document list view
3. Verify that the document appears with "Untitled" as its title instead of showing an empty space

### Why make this change?

This improves the user experience by providing clear visual feedback for documents that don't have titles. Empty titles can be confusing and make it difficult for users to identify their documents in the list view.