### PR TITLE
feat: add sidebar

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,10 @@ import "./globals.css";
 import "./prosemirror.css";
 import CommandMenu from "@/components/CommandMenu";
 import TipText from "@/components/TipText";
+
 import { NotificationProvider } from "@/components/NotificationProvider";
+import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { AppSidebar } from "@/components/AppSidebar";
 
 const lato = Lato({
   variable: "--font-lato",
@@ -26,9 +29,15 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${lato.variable} antialiased`}>
         <NotificationProvider>
-          <CommandMenu />
-          <TipText />
-          {children}
+          <SidebarProvider>
+            <AppSidebar />
+            <CommandMenu />
+            <TipText />
+            <main className="w-full h-full block">
+              <SidebarTrigger />
+              {children}
+            </main>
+          </SidebarProvider>
         </NotificationProvider>
       </body>
     </html>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar";
+
+import { getDocumentTitles } from "@/lib/db";
+import { useState, useEffect } from "react";
+import { MoreHorizontal } from "lucide-react";
+export function AppSidebar() {
+  const [documents, setDocuments] = useState<{ id: string; title: string }[]>(
+    []
+  );
+
+  useEffect(() => {
+    const fetchDocuments = async () => {
+      const documents = await getDocumentTitles();
+      setDocuments(documents);
+    };
+    fetchDocuments();
+  }, []);
+
+  return (
+    <Sidebar>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>
+            <h1>Writings</h1>
+          </SidebarGroupLabel>
+          <SidebarMenu>
+            {documents.map((document) => (
+              <SidebarMenuItem key={document.id}>
+                <SidebarMenuButton>{document.title}</SidebarMenuButton>
+                <SidebarMenuAction>
+                  <MoreHorizontal />
+                </SidebarMenuAction>
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  );
+}


### PR DESCRIPTION
### TL;DR

Added a sidebar component to display document titles in the application.

### What changed?

- Added a new `AppSidebar` component that fetches and displays document titles
- Integrated the sidebar into the root layout using a `SidebarProvider`
- Wrapped the main content in a `main` tag with appropriate styling
- Added a `SidebarTrigger` to toggle the sidebar visibility

### How to test?

1. Run the application and verify the sidebar appears on the left side
2. Check that document titles are properly fetched and displayed in the sidebar
3. Test the sidebar toggle functionality using the trigger
4. Ensure the main content renders correctly alongside the sidebar

### Why make this change?

This change improves navigation by providing users with a sidebar that displays all their documents, making it easier to switch between different writings without having to navigate back to a documents list page. The sidebar enhances the overall user experience by providing quick access to all documents in a consistent UI element.