### PR TITLE
feat: handle data refetching on change

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -3,10 +3,8 @@
 import {
   Sidebar,
   SidebarContent,
-  SidebarFooter,
   SidebarGroup,
   SidebarGroupLabel,
-  SidebarHeader,
   SidebarMenu,
   SidebarMenuAction,
   SidebarMenuButton,
@@ -16,10 +14,13 @@ import {
 import { getDocumentTitles } from "@/lib/db";
 import { useState, useEffect } from "react";
 import { MoreHorizontal } from "lucide-react";
+import { useEditorStore } from "@/store/useEditorStore";
+
 export function AppSidebar() {
   const [documents, setDocuments] = useState<{ id: string; title: string }[]>(
     []
   );
+  const { lastSaved } = useEditorStore();
 
   useEffect(() => {
     const fetchDocuments = async () => {
@@ -27,7 +28,7 @@ export function AppSidebar() {
       setDocuments(documents);
     };
     fetchDocuments();
-  }, []);
+  }, [lastSaved]);
 
   return (
     <Sidebar>

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -17,7 +17,7 @@ const MIN_WORDS = 5;
 const DEBOUNCE_TIME = 1000;
 
 const Editor = () => {
-  const { documentId, setDocumentId } = useEditorStore();
+  const { documentId, setDocumentId, setLastSaved } = useEditorStore();
   const { showNotification } = useNotificationContext();
   const [initialContent, setInitialContent] = useState<JSONContent | undefined>(
     undefined
@@ -49,9 +49,10 @@ const Editor = () => {
       }
 
       saveDocument(documentId, title, json, Date.now());
+      setLastSaved(Date.now());
       showNotification({ message: "Saved just now" });
     }, DEBOUNCE_TIME),
-    [documentId, showNotification]
+    [documentId, showNotification, setLastSaved]
   );
 
   const handleUpdate = useCallback(
@@ -66,7 +67,7 @@ const Editor = () => {
 
       if (documentId) {
         if (wordCount < 1) {
-          debouncedSave(json, "");
+          debouncedSave(json, "Untitled");
           return;
         }
 

--- a/src/store/useEditorStore.ts
+++ b/src/store/useEditorStore.ts
@@ -3,11 +3,15 @@ import { create } from "zustand";
 type EditorStore = {
   documentId: string | null;
   setDocumentId: (documentId: string) => void;
+  lastSaved: number;
+  setLastSaved: (timestamp: number) => void;
 };
 
 const useEditorStore = create<EditorStore>((set) => ({
   documentId: null,
   setDocumentId: (documentId) => set({ documentId }),
+  lastSaved: Date.now(),
+  setLastSaved: (timestamp) => set({ lastSaved: timestamp }),
 }));
 
 export { useEditorStore };


### PR DESCRIPTION
### TL;DR

Added real-time document list refresh when saving documents in the editor.

### What changed?

- Added a `lastSaved` timestamp to the editor store to track when documents are saved
- Updated the sidebar to refresh document list when `lastSaved` changes
- Modified the editor to update the `lastSaved` timestamp when a document is saved
- Changed empty document title from empty string to "Untitled" for better user experience
- Removed unused imports from AppSidebar component

### How to test?

1. Create a new document and save it
2. Verify the document appears in the sidebar immediately after saving
3. Edit an existing document's title and save it
4. Confirm the updated title appears in the sidebar without needing to refresh
5. Create an empty document and verify it shows as "Untitled" in the sidebar

### Why make this change?

Previously, the sidebar document list wouldn't update when creating or editing documents without a manual refresh. This change improves the user experience by automatically refreshing the document list whenever a document is saved, providing immediate feedback and a more responsive interface.