### PR TITLE
feat: add debounce cleanup

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -55,6 +55,12 @@ const Editor = () => {
     [documentId, showNotification, setLastSaved]
   );
 
+  useEffect(() => {
+    return () => {
+      debouncedSave.cancel();
+    };
+  }, [debouncedSave]);
+
   const handleUpdate = useCallback(
     (json: JSONContent, text: string) => {
       const words = text.split(" ").filter((word) => word.length > 0);


### PR DESCRIPTION
### TL;DR

Added cleanup for debounced save function when the Editor component unmounts.

### What changed?

Added a `useEffect` hook with a cleanup function that cancels the debounced save operation when the Editor component unmounts. This prevents potential memory leaks or unnecessary API calls when navigating away from the editor.

### How to test?

1. Open the editor component
2. Make some changes to trigger the debounced save
3. Navigate away from the editor before the debounced save executes
4. Verify that no save operations occur after leaving the editor

### Why make this change?

Without this cleanup, the debounced save function could still execute after the component unmounts, potentially causing errors or unnecessary API calls. This is a best practice for handling debounced functions in React components to prevent memory leaks and ensure proper cleanup of resources.