### PR TITLE
feat: create document fetch hook

### DIFF
--- a/src/hooks/useDocumentTitles.ts
+++ b/src/hooks/useDocumentTitles.ts
@@ -1,0 +1,21 @@
+import { db } from "@/lib/db";
+import { useLiveQuery } from "dexie-react-hooks";
+
+const useDocumentTitles = () => {
+  const documentTitles = useLiveQuery<
+    { id: string; title: string }[]
+  >(async () => {
+    const documents = await db.documents
+      .orderBy("updatedAt")
+      .reverse()
+      .toArray();
+    return documents.map(({ id, title }) => ({
+      id,
+      title: title === "" ? "Untitled" : title,
+    }));
+  }, []);
+
+  return documentTitles;
+};
+
+export { useDocumentTitles };


### PR DESCRIPTION
### TL;DR

Added a new hook to fetch document titles from the database.

### What changed?

Created a new hook `useDocumentTitles` that:
- Retrieves documents from the database ordered by `updatedAt` in descending order
- Maps the results to return only the `id` and `title` properties
- Handles empty titles by replacing them with "Untitled"
- Uses `useLiveQuery` from dexie-react-hooks to keep the data reactive

### How to test?

1. Import the hook in a component: `import { useDocumentTitles } from "@/hooks/useDocumentTitles"`
2. Use it to get document titles: `const documentTitles = useDocumentTitles()`
3. Verify that document titles are displayed correctly
4. Create a document with an empty title and confirm it shows as "Untitled"
5. Update a document and verify the order changes (newest first)

### Why make this change?

This hook provides a reusable way to access document titles across the application, ensuring consistent handling of empty titles and maintaining a consistent sort order. It leverages Dexie's live query capabilities to keep the UI in sync with database changes.