### PR TITLE
feat: add loading skeleton to sidebar document list

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -11,25 +11,52 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 
-import { getDocumentTitles } from "@/lib/db";
-import { useState, useEffect } from "react";
 import { MoreHorizontal } from "lucide-react";
-import { useEditorStore } from "@/store/useEditorStore";
+import { useDocumentTitles } from "@/hooks/useDocumentTitles";
+import dynamic from "next/dynamic";
+
+const SidebarMenuSkeleton = dynamic(
+  () =>
+    import("@/components/ui/sidebar").then((mod) => mod.SidebarMenuSkeleton),
+  {
+    ssr: false,
+  }
+);
+
+const NavProjectsSkeleton = () => {
+  return (
+    <SidebarMenu>
+      {Array.from({ length: 5 }).map((_, index) => (
+        <SidebarMenuItem key={index}>
+          <SidebarMenuSkeleton className="animate-in fade-in slide-in-from-bottom-4 duration-1000" />
+        </SidebarMenuItem>
+      ))}
+    </SidebarMenu>
+  );
+};
+
+const WritingList = () => {
+  const documents = useDocumentTitles();
+
+  if (!documents) {
+    return <NavProjectsSkeleton />;
+  }
+
+  return (
+    <SidebarMenu className="animate-in fade-in slide-in-from-bottom-4 duration-1000">
+      {documents.map((document) => (
+        <SidebarMenuItem key={document.id}>
+          <SidebarMenuButton>{document.title}</SidebarMenuButton>
+          <SidebarMenuAction>
+            <MoreHorizontal />
+          </SidebarMenuAction>
+        </SidebarMenuItem>
+      ))}
+    </SidebarMenu>
+  );
+};
 
 export function AppSidebar() {
-  const [documents, setDocuments] = useState<{ id: string; title: string }[]>(
-    []
-  );
-  const { lastSaved } = useEditorStore();
-
-  useEffect(() => {
-    const fetchDocuments = async () => {
-      const documents = await getDocumentTitles();
-      setDocuments(documents);
-    };
-    fetchDocuments();
-  }, [lastSaved]);
-
   return (
     <Sidebar>
       <SidebarContent>
@@ -37,16 +64,7 @@ export function AppSidebar() {
           <SidebarGroupLabel>
             <h1>Writings</h1>
           </SidebarGroupLabel>
-          <SidebarMenu>
-            {documents.map((document) => (
-              <SidebarMenuItem key={document.id}>
-                <SidebarMenuButton>{document.title}</SidebarMenuButton>
-                <SidebarMenuAction>
-                  <MoreHorizontal />
-                </SidebarMenuAction>
-              </SidebarMenuItem>
-            ))}
-          </SidebarMenu>
+          <WritingList />
         </SidebarGroup>
       </SidebarContent>
     </Sidebar>


### PR DESCRIPTION
### TL;DR

Added loading skeleton for document titles in the sidebar.

### What changed?

- Created a custom hook `useDocumentTitles` to replace direct DB calls
- Added a loading skeleton UI that displays while document titles are being fetched
- Refactored the sidebar to use dynamic imports for the skeleton component
- Split the document list into its own `WritingList` component
- Added smooth fade-in animations for better UX

### How to test?

1. Open the application and observe the loading skeleton in the sidebar
2. Verify that document titles load correctly and replace the skeleton
3. Check that the fade-in animation works properly when documents appear
4. Ensure the sidebar still displays all document titles correctly

### Why make this change?

This change improves the user experience by providing visual feedback during data loading instead of showing an empty sidebar. The skeleton UI gives users a clear indication that content is loading, while the animations make the transition smoother and more polished.