### PR TITLE
refactor: removed unneeded last saved state

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -17,7 +17,7 @@ const MIN_WORDS = 5;
 const DEBOUNCE_TIME = 1000;
 
 const Editor = () => {
-  const { documentId, setDocumentId, setLastSaved } = useEditorStore();
+  const { documentId, setDocumentId } = useEditorStore();
   const { showNotification } = useNotificationContext();
   const [initialContent, setInitialContent] = useState<JSONContent | undefined>(
     undefined
@@ -49,10 +49,9 @@ const Editor = () => {
       }
 
       saveDocument(documentId, title, json, Date.now());
-      setLastSaved(Date.now());
       showNotification({ message: "Saved just now" });
     }, DEBOUNCE_TIME),
-    [documentId, showNotification, setLastSaved]
+    [documentId, showNotification]
   );
 
   useEffect(() => {

--- a/src/store/useEditorStore.ts
+++ b/src/store/useEditorStore.ts
@@ -3,15 +3,11 @@ import { create } from "zustand";
 type EditorStore = {
   documentId: string | null;
   setDocumentId: (documentId: string) => void;
-  lastSaved: number;
-  setLastSaved: (timestamp: number) => void;
 };
 
 const useEditorStore = create<EditorStore>((set) => ({
   documentId: null,
   setDocumentId: (documentId) => set({ documentId }),
-  lastSaved: Date.now(),
-  setLastSaved: (timestamp) => set({ lastSaved: timestamp }),
 }));
 
 export { useEditorStore };


### PR DESCRIPTION
### TL;DR

Removed the `lastSaved` state from the editor store as it was redundant.

### What changed?

- Removed `lastSaved` state and its setter from `useEditorStore`
- Removed references to `setLastSaved` in the `Editor` component
- Simplified the dependency array in the debounced save function

### How to test?

1. Open the editor and make changes to a document
2. Verify that the save functionality still works correctly
3. Confirm that the "Saved just now" notification appears after saving

### Why make this change?

The `lastSaved` timestamp was being stored in the editor store but wasn't being used elsewhere in the application. The save notification already provides feedback to the user about when the document was last saved, making the stored timestamp redundant. This change simplifies the state management by removing unused state.