### PR TITLE
feat: make sidebar inset

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,18 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { Lato } from "next/font/google";
+
 import "./globals.css";
 import "./prosemirror.css";
+
 import CommandMenu from "@/components/CommandMenu";
 import TipText from "@/components/TipText";
-
 import { NotificationProvider } from "@/components/NotificationProvider";
-import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/AppSidebar";
 
 const lato = Lato({
@@ -20,7 +26,7 @@ export const metadata: Metadata = {
   description: "A simple, beautiful, and powerful place to speak your mind.",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
@@ -29,14 +35,16 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${lato.variable} antialiased`}>
         <NotificationProvider>
-          <SidebarProvider>
+          <SidebarProvider defaultOpen={false}>
             <AppSidebar />
             <CommandMenu />
+            <SidebarInset>
+              <main className="w-full h-full block">
+                <SidebarTrigger />
+                {children}
+              </main>
+            </SidebarInset>
             <TipText />
-            <main className="w-full h-full block">
-              <SidebarTrigger />
-              {children}
-            </main>
           </SidebarProvider>
         </NotificationProvider>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import Editor from "@/components/Editor";
 
 export default function Home() {
   return (
-    <div className="flex flex-col items-center min-h-screen font-[family-name:var(--font-lato)]">
+    <div className="flex flex-col items-center font-[family-name:var(--font-lato)]">
       <div className="w-full px-4 md:px-0 lg:w-3/5 flex-1 mt-[30vh] animate-in fade-in slide-in-from-bottom-4 duration-1000">
         <Editor />
       </div>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -58,7 +58,7 @@ const WritingList = () => {
 
 export function AppSidebar() {
   return (
-    <Sidebar>
+    <Sidebar variant="inset">
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupLabel>


### PR DESCRIPTION
### TL;DR

Updated the layout structure to use a sidebar inset pattern and made the sidebar closed by default.

### What changed?

- Modified `RootLayout` to be an async function
- Added `cookies` import from next/headers
- Changed the sidebar structure to use `SidebarInset` component
- Set `defaultOpen={false}` for the `SidebarProvider`
- Updated the `Sidebar` component to use `variant="inset"`
- Moved the main content inside the `SidebarInset` component
- Removed `min-h-screen` from the Home page container to improve layout

### How to test?

1. Load the application and verify the sidebar is closed by default
2. Open the sidebar and confirm it displays correctly with the inset pattern
3. Check that the main content renders properly inside the sidebar inset
4. Verify the layout is responsive across different screen sizes

### Why make this change?

This change improves the user experience by using a more modern inset sidebar pattern, which provides a cleaner layout. Setting the sidebar closed by default gives users more screen space for content on initial load, while still allowing easy access to sidebar functionality when needed.