### PR TITLE
feat: make tip text vanish on open sidebar

### DIFF
--- a/src/components/TipText.tsx
+++ b/src/components/TipText.tsx
@@ -1,13 +1,19 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useSidebar } from "@/components/ui/sidebar";
 
 const TipText = () => {
   const [isMac, setIsMac] = useState(false);
+  const { open } = useSidebar();
 
   useEffect(() => {
     setIsMac(/Mac|iPhone|iPod|iPad/.test(navigator.userAgent));
   }, []);
+
+  if (open) {
+    return null;
+  }
 
   return (
     <div className="fixed bottom-4 left-4 text-sm text-muted-foreground animate-in fade-in slide-in-from-bottom-4 duration-1000 hidden sm:block">


### PR DESCRIPTION
### TL;DR

Added sidebar awareness to the TipText component to hide it when the sidebar is open.

### What changed?

- Imported the `useSidebar` hook to access the sidebar state
- Added a conditional check to return `null` when the sidebar is open, preventing the tip text from rendering

### How to test?

1. Open the application and verify the tip text is visible when the sidebar is closed
2. Open the sidebar and confirm the tip text disappears
3. Close the sidebar and verify the tip text reappears

### Why make this change?

This change improves the UI by preventing the tip text from overlapping or competing with the sidebar when it's open. It creates a cleaner user experience by only showing the command menu tip when it's relevant and not obscured by other UI elements.