### PR TITLE
feat: implement document selection in sidebar

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -13,6 +13,8 @@ import {
 
 import { MoreHorizontal } from "lucide-react";
 import { useDocumentTitles } from "@/hooks/useDocumentTitles";
+import { useEditorStore } from "@/store/useEditorStore";
+
 import dynamic from "next/dynamic";
 
 const SidebarMenuSkeleton = dynamic(
@@ -37,7 +39,7 @@ const NavProjectsSkeleton = () => {
 
 const WritingList = () => {
   const documents = useDocumentTitles();
-
+  const { setDocumentId } = useEditorStore();
   if (!documents) {
     return <NavProjectsSkeleton />;
   }
@@ -45,7 +47,13 @@ const WritingList = () => {
   return (
     <SidebarMenu className="animate-in fade-in slide-in-from-bottom-4 duration-1000">
       {documents.map((document) => (
-        <SidebarMenuItem key={document.id}>
+        <SidebarMenuItem
+          key={document.id}
+          onClick={() => {
+            console.log("setting document id", document.id);
+            setDocumentId(document.id);
+          }}
+        >
           <SidebarMenuButton>{document.title}</SidebarMenuButton>
           <SidebarMenuAction>
             <MoreHorizontal />

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -39,6 +39,7 @@ const Editor = () => {
       setIsLoaded(true);
     };
 
+    setIsLoaded(false);
     loadDocument();
   }, [documentId]);
 


### PR DESCRIPTION
### TL;DR

Added document selection functionality to the sidebar and improved document loading state management.

### What changed?

- Connected the sidebar document list to the editor by importing `useEditorStore` and using `setDocumentId`
- Added click handlers to `SidebarMenuItem` components that set the active document when clicked
- Reset the editor's loading state when switching between documents to properly show loading indicators

### How to test?

1. Open the application and verify that the sidebar displays document titles
2. Click on a document in the sidebar and confirm that it loads in the editor
3. Check the console to see the "setting document id" log message
4. Verify that switching between documents shows the loading state before displaying the new content

### Why make this change?

This change enables users to navigate between documents by clicking on them in the sidebar, improving the application's usability and navigation flow. The loading state reset ensures users get appropriate visual feedback when switching between documents.