### PR TITLE
feat: add selected tab

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -39,7 +39,7 @@ const NavProjectsSkeleton = () => {
 
 const WritingList = () => {
   const documents = useDocumentTitles();
-  const { setDocumentId } = useEditorStore();
+  const { documentId, setDocumentId } = useEditorStore();
   if (!documents) {
     return <NavProjectsSkeleton />;
   }
@@ -50,11 +50,12 @@ const WritingList = () => {
         <SidebarMenuItem
           key={document.id}
           onClick={() => {
-            console.log("setting document id", document.id);
             setDocumentId(document.id);
           }}
         >
-          <SidebarMenuButton>{document.title}</SidebarMenuButton>
+          <SidebarMenuButton isActive={document.id === documentId}>
+            {document.title}
+          </SidebarMenuButton>
           <SidebarMenuAction>
             <MoreHorizontal />
           </SidebarMenuAction>


### PR DESCRIPTION
### TL;DR

Added visual indication for the currently selected document in the sidebar.

### What changed?

- Added `documentId` to the destructured properties from `useEditorStore()`
- Removed a console.log statement that was logging when a document ID was set
- Enhanced the `SidebarMenuButton` component to show an active state by passing an `isActive` prop that compares the current document ID with the selected document ID

### How to test?

1. Open the application and navigate to the writing section
2. Click on different documents in the sidebar
3. Verify that the currently selected document is visually highlighted in the sidebar
4. Confirm that the highlighting updates correctly when switching between documents

### Why make this change?

This change improves the user experience by providing a clear visual indication of which document is currently being viewed or edited. Without this visual feedback, users might be confused about which document they're currently working on, especially when switching between multiple documents.