### PR TITLE
feat: create clear document state

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -44,25 +44,5 @@ const getAllDocuments = async () => {
   return await db.documents.orderBy("updatedAt").reverse().toArray();
 };
 
-const getDocumentTitles = async () => {
-  return await db.documents
-    .orderBy("updatedAt")
-    .reverse()
-    .toArray()
-    .then((documents) =>
-      documents.map(({ id, title }) => ({
-        id,
-        title: title === "" ? "Untitled" : title,
-      }))
-    );
-};
-
 export type { Document };
-export {
-  db,
-  saveDocument,
-  getDocument,
-  deleteDocument,
-  getAllDocuments,
-  getDocumentTitles,
-};
+export { db, saveDocument, getDocument, deleteDocument, getAllDocuments };

--- a/src/store/useEditorStore.ts
+++ b/src/store/useEditorStore.ts
@@ -1,13 +1,16 @@
+import { get } from "http";
 import { create } from "zustand";
 
 type EditorStore = {
   documentId: string | null;
   setDocumentId: (documentId: string) => void;
+  clearDocumentId: () => void;
 };
 
 const useEditorStore = create<EditorStore>((set) => ({
   documentId: null,
   setDocumentId: (documentId) => set({ documentId }),
+  clearDocumentId: () => set({ documentId: null }),
 }));
 
 export { useEditorStore };


### PR DESCRIPTION
### TL;DR

Removed the `getDocumentTitles` function and added a `clearDocumentId` method to the editor store.

### What changed?

- Removed the `getDocumentTitles` function from `src/lib/db.ts` and updated the exports accordingly
- Added a new `clearDocumentId` method to the `useEditorStore` in `src/store/useEditorStore.ts` to reset the document ID to null
- Added the `clearDocumentId` type to the `EditorStore` interface

### How to test?

1. Verify that any components previously using `getDocumentTitles` have been updated to use alternative methods
2. Test the new `clearDocumentId` functionality by:
   - Opening a document to set a document ID
   - Calling `clearDocumentId()`
   - Confirming that the document ID is reset to null

### Why make this change?

The `getDocumentTitles` function was likely redundant as the same functionality can be achieved using `getAllDocuments` with mapping. Adding the `clearDocumentId` method provides a cleaner way to reset the document state when needed, improving the editor's state management capabilities.