### PR TITLE
feat: add document deletion functionality

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { EditorContent, EditorRoot, JSONContent } from "novel";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useRef } from "react";
 import { defaultExtensions } from "@/lib/extensions";
 import { useEditorStore } from "@/store/useEditorStore";
 import { nanoid } from "nanoid";
@@ -23,9 +23,18 @@ const Editor = () => {
     undefined
   );
   const [isLoaded, setIsLoaded] = useState(false);
+  const isNewDocument = useRef(false);
 
   useEffect(() => {
     const loadDocument = async () => {
+      if (isNewDocument.current) {
+        setIsLoaded(true);
+
+        isNewDocument.current = false;
+
+        return;
+      }
+
       if (documentId) {
         const doc = await getDocument(documentId);
 
@@ -68,6 +77,7 @@ const Editor = () => {
 
       if (!documentId && wordCount > MIN_WORDS) {
         const newDocumentId = nanoid();
+        isNewDocument.current = true;
         setDocumentId(newDocumentId);
       }
 


### PR DESCRIPTION
### TL;DR

Added document deletion functionality to the sidebar menu with confirmation dialog.

### What changed?

- Added a dropdown menu to the sidebar's document items with a delete option
- Created a confirmation dialog (`DeleteDialog` component) that appears before deletion
- Implemented the document deletion flow using the `deleteDocument` function
- Added success notification after document deletion
- Fixed an issue with the editor where creating a new document would trigger unnecessary reloading

### How to test?

1. Open the application and select a document from the sidebar
2. Click the three-dot menu icon next to the document title
3. Select "Delete" from the dropdown menu
4. Confirm deletion in the alert dialog
5. Verify that the document is removed from the sidebar and a success notification appears
6. Verify that creating a new document (by typing enough words) works correctly without unnecessary reloading

### Why make this change?

This change provides users with the ability to manage their documents by deleting unwanted content, which is a fundamental feature for any document management system. The confirmation dialog helps prevent accidental deletions, and the notification provides feedback on successful operations.