### PR TITLE
feat: add sidebar separator and fix menu button click handler

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -9,6 +9,7 @@ import {
   SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarSeparator,
 } from "@/components/ui/sidebar";
 
 import { MoreHorizontal } from "lucide-react";
@@ -134,13 +135,13 @@ const WritingList = () => {
   return (
     <SidebarMenu className="animate-in fade-in slide-in-from-bottom-4 duration-1000">
       {documents.map((document) => (
-        <SidebarMenuItem
-          key={document.id}
-          onClick={() => {
-            setDocumentId(document.id);
-          }}
-        >
-          <SidebarMenuButton isActive={document.id === documentId}>
+        <SidebarMenuItem key={document.id}>
+          <SidebarMenuButton
+            isActive={document.id === documentId}
+            onClick={() => {
+              setDocumentId(document.id);
+            }}
+          >
             {document.title}
           </SidebarMenuButton>
           <MenuAction documentId={document.id} />
@@ -158,6 +159,7 @@ export function AppSidebar() {
           <SidebarGroupLabel>
             <h1>Writings</h1>
           </SidebarGroupLabel>
+          <SidebarSeparator />
           <WritingList />
         </SidebarGroup>
       </SidebarContent>


### PR DESCRIPTION
### TL;DR

Improved sidebar UI by fixing click target and adding a separator.

### What changed?

- Moved the `onClick` handler from `SidebarMenuItem` to `SidebarMenuButton` to ensure clicks are properly captured on the button element
- Added a `SidebarSeparator` component between the "Writings" header and the writing list to improve visual hierarchy
- Imported the `SidebarSeparator` component from the UI components

### How to test?

1. Open the application and check the sidebar
2. Verify that clicking on document titles in the sidebar correctly selects the document
3. Confirm that there is now a visual separator between the "Writings" header and the list of documents

### Why make this change?

The previous implementation had the click handler on the menu item container rather than the button itself, which could lead to inconsistent behavior. Adding the separator improves the visual hierarchy in the sidebar, making the interface more intuitive and polished.