### PR TITLE
chore: remove unused imports

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { cookies } from "next/headers";
 import { Lato } from "next/font/google";
 
 import "./globals.css";

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -30,7 +30,6 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 
 import dynamic from "next/dynamic";

--- a/src/store/useEditorStore.ts
+++ b/src/store/useEditorStore.ts
@@ -1,4 +1,3 @@
-import { get } from "http";
 import { create } from "zustand";
 
 type EditorStore = {


### PR DESCRIPTION
### TL;DR

Removed unused imports from multiple files to clean up the codebase.

### What changed?

- Removed unused `cookies` import from `next/headers` in `src/app/layout.tsx`
- Removed unused `AlertDialogTrigger` import from UI components in `src/components/AppSidebar.tsx`
- Removed unused `get` import from `http` module in `src/store/useEditorStore.ts`

### How to test?

1. Verify that the application builds successfully
2. Ensure all functionality works as expected, particularly:
   - The app layout renders correctly
   - The sidebar and its alert dialogs function properly
   - The editor store maintains all its functionality

### Why make this change?

Removing unused imports improves code cleanliness, reduces bundle size slightly, and eliminates potential confusion for developers. This change is part of ongoing code maintenance to keep the codebase clean and efficient.