### PR TITLE
chore: disable Vercel automatic deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
### TL;DR

Disable automatic deployments on Vercel when pushing to Git.

### What changed?

Added a new `vercel.json` configuration file with `deploymentEnabled` set to `false` in the Git settings. This prevents Vercel from automatically creating deployments when new commits are pushed to the repository.

### How to test?

1. Push a new commit to the repository
2. Verify that Vercel does not automatically create a new deployment
3. Confirm that manual deployments still work as expected

### Why make this change?

This change gives more control over the deployment process by requiring manual deployments rather than having every Git push trigger a new deployment. This is useful for repositories where you want to control exactly when deployments occur, rather than having them happen automatically with every push.