### PR TITLE
feat: set window title to "Write" and adjust background color

### DIFF
--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -2,7 +2,7 @@ use tauri::{App, TitleBarStyle, WebviewUrl, WebviewWindowBuilder};
 
 pub fn create_main_window(app: &mut App) -> tauri::Result<()> {
     let win_builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
-        .title("")
+        .title("Write")
         .inner_size(1100.0, 700.0);
 
     #[cfg(target_os = "macos")]
@@ -17,7 +17,7 @@ pub fn create_main_window(app: &mut App) -> tauri::Result<()> {
 
         let ns_window = window.ns_window().unwrap() as id;
         unsafe {
-            let bg_color = NSColor::colorWithRed_green_blue_alpha_(nil, 1.0, 1.0, 1.0, 1.0);
+            let bg_color = NSColor::colorWithRed_green_blue_alpha_(nil, 0.98, 0.98, 0.98, 1.0);
             ns_window.setBackgroundColor_(bg_color);
         }
     }


### PR DESCRIPTION
### TL;DR

Updated the application window title and background color.

### What changed?

- Changed the window title from empty string to "Write"
- Modified the macOS background color from pure white (1.0, 1.0, 1.0) to a slightly off-white color (0.98, 0.98, 0.98)

### How to test?

1. Launch the application on any platform to verify the window title appears as "Write"
2. On macOS, verify the window background has a slightly off-white color instead of pure white

### Why make this change?

The empty window title was not user-friendly, and adding "Write" improves application identification. The slightly off-white background on macOS provides better visual comfort and reduces eye strain compared to pure white, while maintaining a clean aesthetic.