### PR TITLE
feat: enhance keyboard shortcut display with kbd styling

### DIFF
--- a/src/components/TipText.tsx
+++ b/src/components/TipText.tsx
@@ -17,7 +17,11 @@ const TipText = () => {
 
   return (
     <div className="fixed bottom-4 left-4 text-sm text-muted-foreground animate-in fade-in slide-in-from-bottom-4 duration-1000 hidden sm:block">
-      Press {isMac ? "⌘" : "Ctrl"} + K to open command menu
+      Press{" "}
+      <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
+        {isMac ? "⌘" : "Ctrl"} K
+      </kbd>{" "}
+      to open command menu
     </div>
   );
 };


### PR DESCRIPTION
### TL;DR

Enhanced the command menu shortcut display with a styled keyboard shortcut indicator.

### What changed?

Replaced the plain text shortcut indicator with a styled `<kbd>` element that has proper formatting, including a border, background color, and font styling. The shortcut text now appears in a visually distinct keyboard-style button instead of plain text.

### How to test?

1. Run the application and check the bottom left corner of the screen
2. Verify that the "⌘ K" or "Ctrl K" shortcut is now displayed in a styled keyboard button
3. Confirm the text "Press [shortcut] to open command menu" appears correctly
4. Test on both Mac and Windows/Linux to ensure the correct shortcut is shown (⌘ vs Ctrl)

### Why make this change?

This improves the UI by making the keyboard shortcut more visually distinct and following common design patterns for displaying keyboard shortcuts. The styled `<kbd>` element makes it clearer to users that this is an interactive keyboard command they can use, enhancing discoverability of the command menu feature.