### PR TITLE
feat: add pointer-events-none and select-none to TipText

### DIFF
--- a/src/components/TipText.tsx
+++ b/src/components/TipText.tsx
@@ -16,7 +16,7 @@ const TipText = () => {
   }
 
   return (
-    <div className="fixed bottom-4 left-4 text-sm text-muted-foreground animate-in fade-in slide-in-from-bottom-4 duration-1000 hidden sm:block">
+    <div className="fixed bottom-4 left-4 text-sm text-muted-foreground animate-in fade-in slide-in-from-bottom-4 duration-1000 hidden sm:block pointer-events-none select-none">
       Press{" "}
       <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
         {isMac ? "⌘" : "Ctrl"} K


### PR DESCRIPTION
### TL;DR

Added `pointer-events-none` and `select-none` classes to the tip text container.

### What changed?

Updated the TipText component by adding two CSS utility classes to the container div:
- `pointer-events-none`: Prevents the element from receiving pointer events
- `select-none`: Prevents text selection within the element

### How to test?

1. Open the application and verify the tip text appears at the bottom left of the screen
2. Try to hover over or click on the tip text - it should not respond to mouse interactions
3. Try to select the text - it should not be selectable

### Why make this change?

This change improves the user experience by preventing accidental interactions with the tip text. Since this is an informational element that doesn't require user interaction, making it non-interactive ensures it doesn't interfere with other UI elements or cause confusion when users try to interact with content behind it.