### PR TITLE
feat: hide window title instead of setting it to "Write"

### DIFF
--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -2,7 +2,7 @@ use tauri::{App, TitleBarStyle, WebviewUrl, WebviewWindowBuilder};
 
 pub fn create_main_window(app: &mut App) -> tauri::Result<()> {
     let win_builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
-        .title("Write")
+        .hidden_title(true)
         .inner_size(1100.0, 700.0);
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
### TL;DR

Changed the main window to use a hidden title instead of displaying "Write" in the title bar.

### What changed?

Modified the main window configuration in `window.rs` to use `.hidden_title(true)` instead of `.title("Write")`. This removes the visible title text from the application's title bar.

### How to test?

1. Launch the application
2. Verify that the title bar no longer displays the text "Write"
3. Confirm that the title bar functionality still works correctly

### Why make this change?

This change improves the UI aesthetics by removing the redundant title text from the title bar, creating a cleaner and more modern interface appearance. The application is still identifiable through other means (dock/taskbar icons, etc.) without needing the explicit title text in the window.