### PR TITLE
chore: move tw-animate-css to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.2.0",
-    "tw-animate-css": "^1.2.5",
     "zustand": "^5.0.3"
   },
   "devDependencies": {
@@ -47,6 +46,7 @@
     "@types/react-dom": "^19",
     "eslint-config-next": "15.3.0",
     "tailwindcss": "^4",
+    "tw-animate-css": "^1.2.8",
     "typescript": "^5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,6 @@ importers:
       tailwind-merge:
         specifier: ^3.2.0
         version: 3.2.0
-      tw-animate-css:
-        specifier: ^1.2.5
-        version: 1.2.5
       zustand:
         specifier: ^5.0.3
         version: 5.0.3(@types/react@19.1.1)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
@@ -105,6 +102,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.1.3
+      tw-animate-css:
+        specifier: ^1.2.8
+        version: 1.2.8
       typescript:
         specifier: ^5
         version: 5.8.3
@@ -2944,8 +2944,8 @@ packages:
   tunnel-rat@0.1.2:
     resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
 
-  tw-animate-css@1.2.5:
-    resolution: {integrity: sha512-ABzjfgVo+fDbhRREGL4KQZUqqdPgvc5zVrLyeW9/6mVqvaDepXc7EvedA+pYmMnIOsUAQMwcWzNvom26J2qYvQ==}
+  tw-animate-css@1.2.8:
+    resolution: {integrity: sha512-AxSnYRvyFnAiZCUndS3zQZhNfV/B77ZhJ+O7d3K6wfg/jKJY+yv6ahuyXwnyaYA9UdLqnpCwhTRv9pPTBnPR2g==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -6358,7 +6358,7 @@ snapshots:
       - immer
       - react
 
-  tw-animate-css@1.2.5: {}
+  tw-animate-css@1.2.8: {}
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
### TL;DR

Moved `tw-animate-css` from dependencies to devDependencies and upgraded it from version 1.2.5 to 1.2.8.

### What changed?

- Removed `tw-animate-css` (v1.2.5) from the dependencies section
- Added `tw-animate-css` (v1.2.8) to the devDependencies section
- Updated the pnpm-lock.yaml file to reflect these changes

### How to test?

1. Run `pnpm install` to update dependencies
2. Verify that the application builds and runs correctly
3. Check that animations powered by tw-animate-css still function as expected

### Why make this change?

This change properly categorizes `tw-animate-css` as a development dependency since it's likely only needed during build time. Additionally, upgrading to version 1.2.8 brings in the latest improvements and bug fixes from the package.