### PR TITLE
feat: add useDevice hook for platform detection

### DIFF
--- a/src/hooks/useDevice.ts
+++ b/src/hooks/useDevice.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { useState } from "react";
+
+const useDevice = () => {
+  const [isMac, setIsMac] = useState(false);
+  const [metaKey, setMetaKey] = useState("Ctrl");
+
+  useEffect(() => {
+    setIsMac(/Mac|iPhone|iPod|iPad/.test(navigator.userAgent));
+  }, []);
+
+  useEffect(() => {
+    setMetaKey(isMac ? "⌘" : "Ctrl");
+  }, [isMac]);
+
+  return { isMac, metaKey };
+};
+
+export { useDevice };


### PR DESCRIPTION
### TL;DR

Added a new `useDevice` React hook to detect Mac devices and provide the appropriate meta key symbol.

### What changed?

Created a new hook in `src/hooks/useDevice.ts` that:
- Detects if the user is on a Mac device by checking the user agent
- Returns the appropriate meta key symbol (⌘ for Mac, Ctrl for other platforms)
- Provides boolean `isMac` and string `metaKey` values to components

### How to test?

1. Import the hook in a component:
   ```jsx
   import { useDevice } from 'src/hooks/useDevice';
   ```
2. Use the hook in your component:
   ```jsx
   const { isMac, metaKey } = useDevice();
   ```
3. Test on different devices or by changing your user agent to verify:
   - On Mac: `metaKey` should be "⌘"
   - On other platforms: `metaKey` should be "Ctrl"

### Why make this change?

This hook provides a consistent way to display keyboard shortcuts that adapt to the user's platform, improving the user experience by showing the correct key commands based on their operating system.