### PR TITLE
refactor: change tiptext to useDevice hook

### DIFF
--- a/src/components/TipText.tsx
+++ b/src/components/TipText.tsx
@@ -1,15 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useSidebar } from "@/components/ui/sidebar";
+import { useDevice } from "@/hooks/useDevice";
 
 const TipText = () => {
-  const [isMac, setIsMac] = useState(false);
+  const { metaKey } = useDevice();
   const { open } = useSidebar();
-
-  useEffect(() => {
-    setIsMac(/Mac|iPhone|iPod|iPad/.test(navigator.userAgent));
-  }, []);
 
   if (open) {
     return null;
@@ -19,7 +15,7 @@ const TipText = () => {
     <div className="fixed bottom-4 left-4 text-sm text-muted-foreground animate-in fade-in slide-in-from-bottom-4 duration-1000 hidden sm:block pointer-events-none select-none">
       Press{" "}
       <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
-        {isMac ? "⌘" : "Ctrl"} K
+        {metaKey} K
       </kbd>{" "}
       to open command menu
     </div>


### PR DESCRIPTION
### TL;DR

Refactored keyboard shortcut detection using a new `useDevice` hook.

### What changed?

- Removed the local state management for detecting Mac devices
- Replaced the direct user agent check with a new `useDevice` hook
- Simplified the rendering of the meta key (⌘ or Ctrl) in the tip text

### How to test?

1. Open the application on both Mac and Windows/Linux devices
2. Verify that the correct keyboard shortcut is displayed in the tip text (⌘K for Mac, Ctrl+K for Windows/Linux)
3. Confirm that the tip text appears correctly when the sidebar is closed
4. Ensure the tip text disappears when the sidebar is open

### Why make this change?

This change improves code maintainability by extracting device detection logic into a reusable hook. It eliminates the need for component-specific user agent detection and local state management, making the code more concise and following the DRY principle.