### PR TITLE
feat: update cmdk with new items

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -9,10 +9,15 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-} from "./ui/command";
+  CommandShortcut,
+} from "@/components/ui/command";
+
+import { useDevice } from "@/hooks/useDevice";
+import { Download, Heart, MessageCircle, Save, Trash } from "lucide-react";
 
 const CommandMenu = () => {
   const [open, setOpen] = useState(false);
+  const { metaKey } = useDevice();
 
   useEffect(() => {
     const down = (event: KeyboardEvent) => {
@@ -31,10 +36,33 @@ const CommandMenu = () => {
       <CommandInput placeholder="Type a command or search..." />
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
-        <CommandGroup heading="Suggestions">
-          <CommandItem>Save</CommandItem>
-          <CommandItem>Chat</CommandItem>
-          <CommandItem>Export</CommandItem>
+        <CommandGroup heading="Actions">
+          <CommandItem disabled>
+            <Save />
+            <span>Save</span>
+            <CommandShortcut>{metaKey}S</CommandShortcut>
+          </CommandItem>
+          <CommandItem disabled>
+            <MessageCircle />
+            <span>Chat</span>
+            <CommandShortcut>{metaKey}C</CommandShortcut>
+          </CommandItem>
+          <CommandItem disabled>
+            <Download />
+            <span>Export</span>
+          </CommandItem>
+          <CommandItem disabled>
+            <Trash />
+            <span>Delete</span>
+          </CommandItem>
+        </CommandGroup>
+        <CommandGroup heading="Other">
+          <CommandItem
+            onSelect={() => window.open("https://johnnyle.io", "_blank")}
+          >
+            <Heart />
+            <span>Visit Johnnyle.io</span>
+          </CommandItem>
         </CommandGroup>
       </CommandList>
     </CommandDialog>


### PR DESCRIPTION
### TL;DR

Enhanced the CommandMenu component with icons, keyboard shortcuts, and added a link to johnnyle.io.

### What changed?

- Updated import path for command components to use the `@/` alias
- Added `CommandShortcut` component to display keyboard shortcuts
- Integrated the `useDevice` hook to determine the correct meta key (⌘ or Ctrl)
- Added Lucide icons (Download, Heart, MessageCircle, Save, Trash) to menu items
- Restructured command groups from "Suggestions" to "Actions" and "Other"
- Added keyboard shortcuts for Save (⌘/Ctrl+S) and Chat (⌘/Ctrl+C)
- Marked action items as disabled (placeholder functionality)
- Added a working link to johnnyle.io in the "Other" section

### How to test?

1. Open the command menu with the keyboard shortcut
2. Verify that all menu items display with their respective icons
3. Check that keyboard shortcuts are displayed correctly based on the user's OS
4. Click on "Visit Johnnyle.io" and confirm it opens the website in a new tab

### Why make this change?

This update improves the user experience by providing visual cues with icons, displaying available keyboard shortcuts, and adding a functional link. The enhanced command menu follows modern UI patterns and provides better affordances for users to understand available actions.