### PR TITLE
feat: add support for ? and / keyboard shortcuts to open command menu

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState } from "react";
-import { useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   CommandDialog,
   CommandEmpty,
@@ -19,17 +18,34 @@ const CommandMenu = () => {
   const [open, setOpen] = useState(false);
   const { metaKey } = useDevice();
 
-  useEffect(() => {
-    const down = (event: KeyboardEvent) => {
-      if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
-        event.preventDefault();
-        setOpen((open) => !open);
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      switch (event.key) {
+        case "k":
+          if (event.metaKey || event.ctrlKey) {
+            event.preventDefault();
+            setOpen((prevOpen) => !prevOpen);
+          }
+          break;
+        case "?":
+          event.preventDefault();
+          setOpen((prevOpen) => !prevOpen);
+          break;
+        case "/":
+          event.preventDefault();
+          setOpen((prevOpen) => !prevOpen);
+          break;
+        default:
+          break;
       }
-    };
+    },
+    [setOpen]
+  );
 
-    document.addEventListener("keydown", down);
-    return () => document.removeEventListener("keydown", down);
-  }, []);
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
 
   return (
     <CommandDialog open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
### TL;DR

Enhanced command menu keyboard shortcuts to support additional keys for opening the menu.

### What changed?

- Refactored imports to use a single line for React hooks
- Added `useCallback` to optimize the keyboard event handler
- Expanded keyboard shortcuts to open the command menu:
  - Maintained existing `Cmd/Ctrl + K` functionality
  - Added support for the `?` key
  - Added support for the `/` key
- Improved the event handler with a switch statement for better readability
- Renamed `open` to `prevOpen` in state setter for clarity

### How to test?

1. Press `Cmd/Ctrl + K` to verify the command menu still opens/closes
2. Press the `?` key to verify it now opens/closes the command menu
3. Press the `/` key to verify it now opens/closes the command menu
4. Verify that all shortcuts properly prevent default browser behavior

### Why make this change?

This change improves user accessibility by providing multiple keyboard shortcuts to access the command menu. The additional shortcuts (`?` and `/`) are common conventions in many applications, making the interface more intuitive for users familiar with these patterns. The code refactoring also improves performance through proper memoization of the event handler.