### PR TITLE
feat: add toggle sidebar command

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -10,12 +10,21 @@ import {
   CommandList,
   CommandShortcut,
 } from "@/components/ui/command";
+import { useSidebar } from "./ui/sidebar";
 
 import { useDevice } from "@/hooks/useDevice";
-import { Download, Heart, MessageCircle, Save, Trash } from "lucide-react";
+import {
+  Download,
+  Heart,
+  MessageCircle,
+  Save,
+  Sidebar,
+  Trash,
+} from "lucide-react";
 
 const CommandMenu = () => {
   const [open, setOpen] = useState(false);
+  const { toggleSidebar } = useSidebar();
   const { metaKey } = useDevice();
 
   const handleKeyDown = useCallback(
@@ -52,6 +61,24 @@ const CommandMenu = () => {
       <CommandInput placeholder="Type a command or search..." />
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Suggestions">
+          <CommandItem
+            onSelect={() => window.open("https://johnnyle.io", "_blank")}
+          >
+            <Heart />
+            <span>Visit Johnnyle.io</span>
+          </CommandItem>
+          <CommandItem
+            onSelect={() => {
+              toggleSidebar();
+              setOpen(false);
+            }}
+          >
+            <Sidebar />
+            <span>Toggle Sidebar</span>
+            <CommandShortcut>{metaKey}B</CommandShortcut>
+          </CommandItem>
+        </CommandGroup>
         <CommandGroup heading="Actions">
           <CommandItem disabled>
             <Save />
@@ -70,14 +97,6 @@ const CommandMenu = () => {
           <CommandItem disabled>
             <Trash />
             <span>Delete</span>
-          </CommandItem>
-        </CommandGroup>
-        <CommandGroup heading="Other">
-          <CommandItem
-            onSelect={() => window.open("https://johnnyle.io", "_blank")}
-          >
-            <Heart />
-            <span>Visit Johnnyle.io</span>
           </CommandItem>
         </CommandGroup>
       </CommandList>


### PR DESCRIPTION
### TL;DR

Added a toggle sidebar option to the command menu with keyboard shortcut support.

### What changed?

- Added a new "Suggestions" command group that includes:
  - The existing "Visit Johnnyle.io" option (moved from "Other" group)
  - A new "Toggle Sidebar" option with keyboard shortcut (⌘B or Ctrl+B)
- Imported the `useSidebar` hook and `Sidebar` icon
- Implemented sidebar toggle functionality when the command is selected
- Reorganized the command groups for better user experience
- Removed the "Other" command group

### How to test?

1. Open the command menu (⌘K or Ctrl+K)
2. Verify the new "Suggestions" group appears with both options
3. Select "Toggle Sidebar" and confirm the sidebar toggles open/closed
4. Try using the keyboard shortcut (⌘B or Ctrl+B) to toggle the sidebar

### Why make this change?

This enhancement improves the command menu's utility by providing quick access to the sidebar toggle functionality, making the application more keyboard-friendly and improving overall navigation efficiency. The reorganization of command groups creates a more intuitive user experience by prioritizing suggested actions.