### PR TITLE
feat: add calculateTitle utility function

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,24 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+import { JSONContent } from "novel";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }
+
+/**
+ * Calculates a document title based on the first few words of its text content.
+ * Defaults to "Untitled" if text is empty or null.
+ * @param text The text content of the document.
+ * @returns The calculated title string.
+ */
+export const calculateTitle = (text: string | null): string => {
+  if (!text) {
+    return "Untitled";
+  }
+  const words = text.split(" ").filter((word) => word.length > 0);
+  if (words.length < 1) {
+    return "Untitled";
+  }
+  return words.slice(0, 5).join(" ");
+};


### PR DESCRIPTION
### TL;DR

Added a new utility function to generate document titles from content text.

### What changed?

- Added a new `calculateTitle` utility function that extracts the first 5 words from a document's text content to create a title
- The function handles empty or null text by returning "Untitled"
- Added JSDoc comments to explain the function's purpose and parameters
- Fixed missing semicolons in the existing code for consistency

### How to test?

1. Import the `calculateTitle` function in a component
2. Test with various text inputs:
   - `calculateTitle("This is a sample document with content")` should return "This is a sample document"
   - `calculateTitle("")` should return "Untitled"
   - `calculateTitle(null)` should return "Untitled"

### Why make this change?

This utility function provides a consistent way to generate document titles automatically from content, improving the user experience by eliminating the need for manual title entry. It's particularly useful for applications where users create documents but may not explicitly set titles.