### PR TITLE
feat: enhance editor store with content management and saving functionality

### DIFF
--- a/src/store/useEditorStore.ts
+++ b/src/store/useEditorStore.ts
@@ -1,15 +1,47 @@
+import { saveDocument } from "@/lib/db";
+import { calculateTitle } from "@/lib/utils";
+import { JSONContent } from "novel";
 import { create } from "zustand";
 
 type EditorStore = {
   documentId: string | null;
   setDocumentId: (documentId: string) => void;
   clearDocumentId: () => void;
+  jsonContent: JSONContent | null;
+  textContent: string | null;
+  setEditorContent: (json: JSONContent | null, text: string | null) => void;
+  saveCurrentDocument: () => Promise<boolean>;
 };
 
-const useEditorStore = create<EditorStore>((set) => ({
+const useEditorStore = create<EditorStore>((set, get) => ({
   documentId: null,
+  jsonContent: null,
+  textContent: null,
   setDocumentId: (documentId) => set({ documentId }),
-  clearDocumentId: () => set({ documentId: null }),
+  clearDocumentId: () =>
+    set({ documentId: null, jsonContent: null, textContent: null }),
+  setEditorContent: (json, text) =>
+    set({ jsonContent: json, textContent: text }),
+  saveCurrentDocument: async () => {
+    const { documentId, jsonContent, textContent } = get();
+
+    if (!documentId) {
+      return false;
+    }
+
+    if (!jsonContent) {
+      return false;
+    }
+
+    const title = calculateTitle(textContent);
+
+    try {
+      await saveDocument(documentId, title, jsonContent, Date.now());
+      return true;
+    } catch (error) {
+      return false;
+    }
+  },
 }));
 
 export { useEditorStore };


### PR DESCRIPTION
### TL;DR

Enhanced the editor store with document content management and save functionality.

### What changed?

- Added `jsonContent` and `textContent` state properties to track editor content
- Implemented `setEditorContent` method to update content state
- Created `saveCurrentDocument` async method that:
  - Saves the current document to the database
  - Automatically calculates a title from the text content
  - Returns success/failure status
- Updated `clearDocumentId` to also clear content state
- Added imports for new database and utility functions

### How to test?

1. Create or open a document in the editor
2. Make changes to the document content
3. Verify the content is properly stored in the editor state
4. Call `saveCurrentDocument()` and confirm it returns true
5. Check that the document is saved with the correct title in the database

### Why make this change?

This change provides essential functionality for persisting document content. By tracking both JSON and text representations of the document content, we can efficiently save documents while also generating appropriate titles from the text content. The addition of the save functionality creates a complete document management flow.