### PR TITLE
fix: remove ? cmdk (prevent users from typing ?)

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -61,14 +61,6 @@ const CommandMenu = () => {
             setOpen((prevOpen) => !prevOpen);
           }
           break;
-        case "?":
-          event.preventDefault();
-          setOpen((prevOpen) => !prevOpen);
-          break;
-        case "/":
-          event.preventDefault();
-          setOpen((prevOpen) => !prevOpen);
-          break;
         case "s":
           if (event.metaKey || event.ctrlKey) {
             event.preventDefault();


### PR DESCRIPTION
### TL;DR

Removed keyboard shortcuts for opening the command menu with "?" and "/" keys.

### What changed?

Removed the event handlers for the "?" and "/" keys in the CommandMenu component. Previously, pressing either of these keys would toggle the command menu open/closed, but this functionality has been removed while maintaining the other keyboard shortcuts.

### How to test?

1. Open the application
2. Try pressing the "?" key - the command menu should no longer open
3. Try pressing the "/" key - the command menu should no longer open
4. Verify that other keyboard shortcuts (like Cmd+K or Ctrl+K) still work to open the command menu

### Why make this change?

Likely to prevent conflicts with other functionality that might use these keys (such as search functionality that commonly uses "/"). This change simplifies the keyboard shortcut system and potentially reduces accidental command menu activations.