### PR TITLE
Add New Writing button and improve editor clearing

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -12,7 +12,7 @@ import {
   SidebarSeparator,
 } from "@/components/ui/sidebar";
 
-import { MoreHorizontal } from "lucide-react";
+import { MoreHorizontal, Plus } from "lucide-react";
 import { useDocumentTitles } from "@/hooks/useDocumentTitles";
 import { useEditorStore } from "@/store/useEditorStore";
 import {
@@ -31,6 +31,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 
 import dynamic from "next/dynamic";
 import { deleteDocument } from "@/lib/db";
@@ -123,6 +124,26 @@ const MenuAction = ({ documentId }: { documentId: string }) => {
   );
 };
 
+const NewWritingButton = () => {
+  const { clearDocumentId, setEditorContent } = useEditorStore();
+
+  const handleNewWriting = () => {
+    clearDocumentId();
+    setEditorContent(null, null);
+  };
+
+  return (
+    <Button
+      onClick={handleNewWriting}
+      size="sm"
+      className="w-full my-2 flex items-center gap-2"
+    >
+      <Plus size={16} />
+      New Writing
+    </Button>
+  );
+};
+
 const WritingList = () => {
   const documents = useDocumentTitles();
   const { documentId, setDocumentId } = useEditorStore();
@@ -158,7 +179,7 @@ export function AppSidebar() {
           <SidebarGroupLabel>
             <h1>Writings</h1>
           </SidebarGroupLabel>
-          <SidebarSeparator />
+          <NewWritingButton />
           <WritingList />
         </SidebarGroup>
       </SidebarContent>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -9,7 +9,6 @@ import {
   SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarSeparator,
 } from "@/components/ui/sidebar";
 
 import { MoreHorizontal, Plus } from "lucide-react";
@@ -68,11 +67,19 @@ const DeleteDialog = ({
   onOpenChange: (open: boolean) => void;
 }) => {
   const { showNotification } = useNotificationContext();
-  const { clearDocumentId } = useEditorStore();
+  const {
+    documentId: currentDocumentId,
+    clearDocumentId,
+    setEditorContent,
+  } = useEditorStore();
 
   const handleDelete = async () => {
     await deleteDocument(documentId);
-    clearDocumentId();
+
+    if (documentId === currentDocumentId) {
+      clearDocumentId();
+      setEditorContent(null, null);
+    }
 
     showNotification({ message: "Deleted successfully" });
 

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -18,12 +18,14 @@ const MIN_WORDS = 4;
 const DEBOUNCE_TIME = 1000;
 
 const Editor = () => {
-  const { documentId, setDocumentId, setEditorContent, isSaving, setSaving } = useEditorStore();
+  const { documentId, setDocumentId, setEditorContent, isSaving, setSaving } =
+    useEditorStore();
   const { showNotification } = useNotificationContext();
   const [initialContent, setInitialContent] = useState<JSONContent | undefined>(
     undefined
   );
   const [isLoaded, setIsLoaded] = useState(false);
+  const [editorKey, setEditorKey] = useState(0);
   const isNewDocument = useRef(false);
 
   useEffect(() => {
@@ -47,7 +49,9 @@ const Editor = () => {
       }
 
       if (!documentId) {
+        setInitialContent(undefined);
         setEditorContent(null, null);
+        setEditorKey((prev) => prev + 1);
         setIsLoaded(true);
         return;
       }
@@ -60,23 +64,26 @@ const Editor = () => {
   }, [documentId, setEditorContent]);
 
   const debouncedSave = useCallback(
-    debounce(async (json: JSONContent, title: string, currentDocumentId: string) => {
-      if (!currentDocumentId || isSaving) {
-        return;
-      }
+    debounce(
+      async (json: JSONContent, title: string, currentDocumentId: string) => {
+        if (!currentDocumentId || isSaving) {
+          return;
+        }
 
-      setSaving(true);
-      
-      try {
-        await saveDocument(currentDocumentId, title, json, Date.now());
-        showNotification({ message: "Saved just now" });
-      } catch (error) {
-        console.error("Failed to save document:", error);
-        showNotification({ message: "Failed to save" });
-      } finally {
-        setSaving(false);
-      }
-    }, DEBOUNCE_TIME),
+        setSaving(true);
+
+        try {
+          await saveDocument(currentDocumentId, title, json, Date.now());
+          showNotification({ message: "Saved just now" });
+        } catch (error) {
+          console.error("Failed to save document:", error);
+          showNotification({ message: "Failed to save" });
+        } finally {
+          setSaving(false);
+        }
+      },
+      DEBOUNCE_TIME
+    ),
     [isSaving, setSaving, showNotification]
   );
 
@@ -133,6 +140,7 @@ const Editor = () => {
     <div className="h-full">
       <EditorRoot>
         <EditorContent
+          key={editorKey}
           className="h-full"
           extensions={extensions}
           initialContent={initialContent}


### PR DESCRIPTION
### TL;DR

Added a "New Writing" button to the sidebar and fixed editor content clearing issues to improve the user experience when creating new documents and managing existing ones.

### What changed?

- **New Writing button**: Added a prominent button at the top of the sidebar with Plus icon for easy document creation
- **Editor clearing mechanism**: Implemented key-based re-rendering to properly clear editor content when switching to new documents
- **Delete behavior improvement**: Enhanced delete functionality to clear editor when deleting the currently selected document
- **Code cleanup**: Removed unused `SidebarSeparator` import and improved component organization

### How to test?

1. **New Writing functionality**:
   - Click the "New Writing" button in the sidebar
   - Verify editor shows a completely blank state (no previous content)
   - Type content, then click "New Writing" again to confirm editor clears
2. **Delete current document**:
   - Select any document and ensure it's displayed in the editor
   - Delete that document using the dropdown menu
   - Verify the editor clears completely after deletion
3. **Delete non-current document**:
   - Select one document, then delete a different document
   - Verify the editor content remains unchanged

### Why make this change?

The original implementation had UX issues where:
- **No easy way to create new documents**: Users had to manually clear content or remember the 5-word auto-creation rule
- **Stale editor content**: When switching to new documents or deleting current ones, the editor would retain previous content
- **Confusing state management**: The Novel EditorContent component doesn't automatically re-render when initialContent changes

These improvements provide a cleaner, more intuitive writing experience with proper state management.