### PR TITLE
feat: add ChatGPT integration for sharing writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ pnpm tauri:build
 - `src/lib/` - Utilities and database functions
 - `src/store/` - Zustand state management
 - `src-tauri/` - Tauri desktop app configuration
+
+## Credits
+
+ChatGPT integration inspired by [Farza's freewrite](https://github.com/farzaa/freewrite) - [freewrite.io](https://freewrite.io/)

--- a/src/components/ChatButton.tsx
+++ b/src/components/ChatButton.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEditorStore } from "@/store/useEditorStore";
+import { useNotificationContext } from "@/components/NotificationProvider";
+import { generateChatGPTUrl, canShareWithChatGPT } from "@/lib/chatgpt";
+
+const ChatButton = () => {
+  const { textContent } = useEditorStore();
+  const { showNotification } = useNotificationContext();
+  const canShareChat = canShareWithChatGPT(textContent);
+
+  const handleChatGPT = () => {
+    if (!textContent) {
+      showNotification({ message: "No content to share with ChatGPT" });
+      return;
+    }
+
+    try {
+      const chatGPTUrl = generateChatGPTUrl(textContent);
+      window.open(chatGPTUrl, "_blank");
+    } catch {
+      showNotification({ message: "Failed to generate ChatGPT link" });
+    }
+  };
+
+  return (
+    <button
+      onClick={handleChatGPT}
+      disabled={!canShareChat}
+      className={`fixed bottom-4 right-4 text-sm text-muted-foreground transition-opacity hidden sm:block ${
+        canShareChat 
+          ? "opacity-100 hover:text-foreground cursor-pointer" 
+          : "opacity-50 cursor-not-allowed"
+      }`}
+    >
+      Chat
+    </button>
+  );
+};
+
+export default ChatButton;

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -10,7 +10,7 @@ import { EditorContent, EditorRoot, JSONContent } from "novel";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Skeleton } from "@/components/ui/skeleton";
-import { calculateTitle } from "@/lib/utils";
+import { calculateTitle, extractTextFromJSON } from "@/lib/utils";
 
 const extensions = [...defaultExtensions];
 
@@ -43,6 +43,8 @@ const Editor = () => {
 
         if (doc) {
           setInitialContent(doc.content);
+          const textFromJSON = extractTextFromJSON(doc.content);
+          setEditorContent(doc.content, textFromJSON);
           setIsLoaded(true);
           return;
         }

--- a/src/components/NotificationProvider.tsx
+++ b/src/components/NotificationProvider.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, ReactNode } from "react";
 import { useNotification } from "@/hooks/useNotification";
 import NotificationText from "./NotificationText";
+import ChatButton from "./ChatButton";
 
 type NotificationContextType = {
   showNotification: (options: { message: string; duration?: number }) => void;
@@ -29,6 +30,7 @@ export const NotificationProvider = ({ children }: { children: ReactNode }) => {
     <NotificationContext.Provider value={{ showNotification }}>
       {children}
       <NotificationText message={message} isVisible={isVisible} />
+      <ChatButton />
     </NotificationContext.Provider>
   );
 };

--- a/src/components/NotificationText.tsx
+++ b/src/components/NotificationText.tsx
@@ -8,7 +8,7 @@ type NotificationTextProps = {
 const NotificationText = ({ message, isVisible }: NotificationTextProps) => {
   return (
     <div
-      className={`fixed bottom-4 right-4 text-sm text-muted-foreground animate-in fade-in slide-in-from-bottom-4 duration-1000 ${
+      className={`fixed top-4 right-4 text-sm text-muted-foreground animate-in fade-in slide-in-from-top-4 duration-1000 ${
         isVisible ? "opacity-100" : "opacity-0"
       } transition-opacity hidden sm:block`}
     >

--- a/src/lib/chatgpt.ts
+++ b/src/lib/chatgpt.ts
@@ -1,0 +1,30 @@
+// Prompt inspired by Farzaa freewrite: https://github.com/farzaa/freewrite
+const CHATGPT_PROMPT_TEMPLATE = `Below is my journal entry. What do you think? Talk through it with me like a friend. Don't therapize me and give me a whole breakdown, don't repeat my thoughts with headings. Really take all of this, and tell me back stuff truly as if you're an old friend.
+    
+Keep it casual, don't say "yo", help me make new connections I don't see, comfort, validate, challenge, all of it. Don't be afraid to say a lot. Format with markdown headings if needed.
+
+Do not just go through every single thing I say, and say it back to me. You need to process everything I say, make connections I don't see, and deliver it all back to me as a story that makes me feel what you think I want to feel. That's what the best therapists do.
+
+Ideally, your style/tone should sound like the user themselves. It's as if the user is hearing their own tone but it should still feel different, because you have different things to say and don't just repeat back what they say.
+
+My entry:
+
+{content}`;
+
+export function generateChatGPTUrl(content: string): string {
+  if (!content || content.trim().length === 0) {
+    throw new Error("No content available to share with ChatGPT");
+  }
+
+  const promptWithContent = CHATGPT_PROMPT_TEMPLATE.replace(
+    "{content}",
+    content.trim()
+  );
+  const encodedMessage = encodeURIComponent(promptWithContent);
+
+  return `https://chat.openai.com/?m=${encodedMessage}`;
+}
+
+export function canShareWithChatGPT(content: string | null): boolean {
+  return !!(content && content.trim().length > 0);
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,6 +7,37 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
+ * Extracts plain text from Tiptap/Novel JSONContent
+ * @param content The JSONContent to extract text from
+ * @returns The plain text string
+ */
+export const extractTextFromJSON = (content: JSONContent | null): string => {
+  if (!content) return "";
+
+  let text = "";
+
+  if (content.text) {
+    text += content.text;
+  }
+
+  if (content.content) {
+    for (const child of content.content) {
+      text += extractTextFromJSON(child);
+    }
+  }
+
+  // Add space after block elements
+  if (
+    content.type &&
+    ["paragraph", "heading", "listItem"].includes(content.type)
+  ) {
+    text += " ";
+  }
+
+  return text;
+};
+
+/**
  * Calculates a document title based on the first few words of its text content.
  * Defaults to "Untitled" if text is empty or null.
  * @param text The text content of the document.


### PR DESCRIPTION
## TL;DR

Added ChatGPT integration allowing users to share their writing with ChatGPT through both command menu and a dedicated chat button, with a conversational prompt for friendly feedback.

## What changed?

- **ChatGPT Integration**: Created utility functions to generate ChatGPT URLs with custom conversational prompts
- **Text Extraction Fix**: Added utility to extract plain text from JSONContent and fixed document loading to populate textContent
- **UI Repositioning**: Moved notifications to top-right corner to make space for chat features  
- **Command Menu Enhancement**: Added "Chat with ChatGPT" option to command palette with proper enable/disable logic
- **Chat Button**: Added bottom-right chat button with notification text styling and hover effects
- **Documentation**: Added credits to Farza's freewrite project for inspiration

## How to test?

1. **Write some content**: Create a document with at least 5 words to enable auto-save
2. **Test command menu**: Press Cmd/Ctrl+K and select "Chat with ChatGPT" 
3. **Test chat button**: Click the "Chat" button in bottom-right corner
4. **Verify ChatGPT opens**: Should open ChatGPT with friendly conversational prompt
5. **Test edge cases**: Try with no content (should show helpful notification)
6. **Test document switching**: Switch between documents and verify chat button enables/disables correctly

## Why make this change?

This enables users to get friendly, conversational feedback on their writing by easily sharing it with ChatGPT. The integration uses a carefully crafted prompt that encourages ChatGPT to respond like a supportive friend rather than a clinical therapist, making connections and providing validation while challenging ideas constructively.