### PR TITLE
Add welcome document for first-time users

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/AppSidebar";
+import { DbInitializer } from "@/components/DbInitializer";
 
 const lato = Lato({
   variable: "--font-lato",
@@ -33,6 +34,7 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body className={`${lato.variable} antialiased`}>
+        <DbInitializer />
         <NotificationProvider>
           <SidebarProvider defaultOpen={false}>
             <AppSidebar />

--- a/src/components/DbInitializer.tsx
+++ b/src/components/DbInitializer.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+import { initializeDatabase } from "@/lib/init-db";
+import { useEditorStore } from "@/store/useEditorStore";
+
+export const DbInitializer = () => {
+  const { setDocumentId } = useEditorStore();
+
+  useEffect(() => {
+    const initialize = async () => {
+      const { isFirstTime, welcomeDocId } = await initializeDatabase();
+      
+      if (isFirstTime && welcomeDocId) {
+        setDocumentId(welcomeDocId);
+      }
+    };
+    
+    initialize();
+  }, [setDocumentId]);
+
+  return null;
+};

--- a/src/lib/init-db.ts
+++ b/src/lib/init-db.ts
@@ -1,0 +1,106 @@
+import { db, saveDocument } from "./db";
+import type { JSONContent } from "novel";
+
+const WELCOME_DOC_ID = "welcome-guide";
+const INIT_FLAG_KEY = "db-initialized";
+
+const welcomeContent: JSONContent = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "Write whatever is on your mind. Don't worry about grammar, just write. After, click chat."
+        }
+      ]
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "All the stuff here is local. We save it in your browser. Here's how you can check:"
+        }
+      ]
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "1. Right-click anywhere on this page"
+        }
+      ]
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "2. Click \"Inspect\" or \"Inspect Element\""
+        }
+      ]
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "3. Go to the \"Application\" tab (might be under >> if hidden)"
+        }
+      ]
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "4. Look for \"IndexedDB\" in the left sidebar"
+        }
+      ]
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "5. Click the arrow next to \"WriteDB\" - that's where your words live"
+        }
+      ]
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "Nothing leaves your computer unless you choose to share it. This is your space."
+        }
+      ]
+    }
+  ]
+};
+
+export const initializeDatabase = async () => {
+  try {
+    const hasBeenInitialized = localStorage.getItem(INIT_FLAG_KEY);
+    
+    if (!hasBeenInitialized) {
+      await saveDocument(
+        WELCOME_DOC_ID,
+        "Write whatever is on your",
+        welcomeContent,
+        Date.now()
+      );
+      
+      localStorage.setItem(INIT_FLAG_KEY, "true");
+      return { isFirstTime: true, welcomeDocId: WELCOME_DOC_ID };
+    }
+    
+    return { isFirstTime: false, welcomeDocId: null };
+  } catch (error) {
+    console.error("Failed to initialize database:", error);
+    return { isFirstTime: false, welcomeDocId: null };
+  }
+};

--- a/src/store/useEditorStore.ts
+++ b/src/store/useEditorStore.ts
@@ -49,7 +49,7 @@ const useEditorStore = create<EditorStore>((set, get) => ({
       await saveDocument(documentId, title, jsonContent, Date.now());
       set({ isSaving: false });
       return true;
-    } catch (error) {
+    } catch {
       set({ isSaving: false });
       return false;
     }


### PR DESCRIPTION
## TL;DR

Added an initial welcome document that appears only on first visit to guide new users and explain the app's privacy model.

## What changed?

- **Database initialization**: Created system to add welcome document on first app visit
- **One-time behavior**: Document only appears once and won't return if deleted
- **Auto-selection**: Welcome document automatically selected on first visit
- **Privacy explanation**: Clear instructions for users to verify local storage
- **Personal tone**: Writing feels like a friend explaining how the app works

## How to test?

1. **First visit simulation**: 
   - Clear browser localStorage for the site
   - Refresh the page
   - Verify welcome document appears and is selected
2. **Deletion persistence**:
   - Delete the welcome document
   - Refresh the page
   - Confirm it doesn't return
3. **Storage verification**:
   - Follow the steps in the welcome document
   - Verify you can see WriteDB in IndexedDB

## Why make this change?

New users need immediate guidance on how to use the app and reassurance about privacy. The welcome document provides both in a personal, friendly tone while demonstrating the app's core functionality from the first interaction.