### PR TITLE
feat: increase padding for corner UI elements

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -41,7 +41,9 @@ export default async function RootLayout({
             <CommandMenu />
             <SidebarInset>
               <main className="w-full h-full block">
-                <SidebarTrigger />
+                <div className="p-2">
+                  <SidebarTrigger />
+                </div>
                 {children}
               </main>
             </SidebarInset>

--- a/src/components/ChatButton.tsx
+++ b/src/components/ChatButton.tsx
@@ -27,7 +27,7 @@ const ChatButton = () => {
     <button
       onClick={handleChatGPT}
       disabled={!canShareChat}
-      className={`fixed bottom-4 right-4 text-sm text-muted-foreground transition-opacity ${
+      className={`fixed bottom-8 right-8 text-sm text-muted-foreground transition-opacity ${
         canShareChat 
           ? "opacity-100 hover:text-foreground cursor-pointer" 
           : "opacity-50 cursor-not-allowed"

--- a/src/components/NotificationText.tsx
+++ b/src/components/NotificationText.tsx
@@ -8,7 +8,7 @@ type NotificationTextProps = {
 const NotificationText = ({ message, isVisible }: NotificationTextProps) => {
   return (
     <div
-      className={`fixed top-4 right-4 text-sm text-muted-foreground animate-in fade-in slide-in-from-top-4 duration-1000 ${
+      className={`fixed top-8 right-8 text-sm text-muted-foreground animate-in fade-in slide-in-from-top-4 duration-1000 ${
         isVisible ? "opacity-100" : "opacity-0"
       } transition-opacity hidden sm:block`}
     >

--- a/src/components/TipText.tsx
+++ b/src/components/TipText.tsx
@@ -12,7 +12,7 @@ const TipText = () => {
   }
 
   return (
-    <div className="fixed bottom-4 left-4 text-sm text-muted-foreground animate-in fade-in slide-in-from-bottom-4 duration-1000 hidden sm:block pointer-events-none select-none">
+    <div className="fixed bottom-8 left-8 text-sm text-muted-foreground animate-in fade-in slide-in-from-bottom-4 duration-1000 hidden sm:block pointer-events-none select-none">
       Press{" "}
       <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
         {metaKey} K


### PR DESCRIPTION
### TL;DR

Increased padding for all four corner UI elements to provide better visual spacing from the screen edges.

### What changed?

- **NotificationText**: Updated positioning from `top-4 right-4` to `top-8 right-8` for better top-right corner spacing
- **SidebarTrigger**: Wrapped in a container div with `p-2` padding to move it away from the top-left edge
- **TipText**: Updated positioning from `bottom-4 left-4` to `bottom-8 left-8` for improved bottom-left corner spacing  
- **ChatButton**: Updated positioning from `bottom-4 right-4` to `bottom-8 right-8` for better bottom-right corner spacing

### How to test?

1. **Notification display**: Trigger a notification and verify it appears with more spacing from the top-right corner
2. **Sidebar toggle**: Check that the sidebar toggle button has more breathing room from the top-left corner
3. **Command menu tip**: Verify the "Press ⌘K" tip text is positioned further from the bottom-left corner when sidebar is closed
4. **Chat button**: Confirm the Chat button has increased spacing from the bottom-right corner when content is available

### Why make this change?

The previous positioning with 1rem (16px) padding felt too close to the screen edges, creating a cramped appearance. Increasing to 2rem (32px) provides better visual breathing room and improves the overall user experience by making corner elements feel less constrained against the viewport boundaries.

🤖 Generated with [Claude Code](https://claude.ai/code)